### PR TITLE
Barebones Admin Console track for automation

### DIFF
--- a/instruqt/providing-a-console/track.yml
+++ b/instruqt/providing-a-console/track.yml
@@ -1,0 +1,30 @@
+slug: providing-a-console
+title: Providing an Administration Console
+teaser: |-
+  Add an administration console to your application to allow
+  for graphical installation, troubleshooting, and management.
+description: |-
+
+  Some customers appreciate a graphical user interface to support installation,
+  configuration, troubleshooting, and management of your application. Learn how
+  the Replicated Admin Console provides those capabilities to your customers
+  with a few small changes to how you release your and distribute.
+
+   **This lab demonstrates how to:**
+
+   * Prepare an installation package that includes the Replicated Admin Console.
+   * Provide a user interface for your customer to configure their installation.
+   * Install an application the way your customer will do it.
+icon: https://storage.googleapis.com/shared-lab-assets/icons/red/admin.png 
+tags: 
+- premium-plans
+- kots
+- helm
+owner: replicated
+developers:
+- chuck@replicated.com
+maintenance: true
+lab_config:
+  overlay: false
+  width: 33
+  position: right

--- a/instruqt/providing-a-console/vendor/vendor.json
+++ b/instruqt/providing-a-console/vendor/vendor.json
@@ -1,0 +1,7 @@
+{
+    "name": "Harbor",
+    "slug": "harbor",
+    "customer": "Omozan",
+    "yaml_dir": "",
+    "k8s_installer_yaml_path": ""
+}


### PR DESCRIPTION
TL;DR
-----

Creates a barebones lab for addding the admin console to Harbor

Details
-------

Provides a bare minimum to distinguish the new lab I'm working on so I can get the automation to see it and be able to work without setting customer URL parameters. Lab is in maintenance so should be fine.

Goal of the lab is to shift from Helm-based to KOTS-based distribution for the Harbor Helm application that's used in the Builders experience labs. We're looking for examples for this to support docs and demos, so a lab felt like a good place to start.