### PR TITLE
Pinning Harbor version

### DIFF
--- a/instruqt/distributing-with-replicated/01-preparing-to-use-the-sdk/assignment.md
+++ b/instruqt/distributing-with-replicated/01-preparing-to-use-the-sdk/assignment.md
@@ -54,7 +54,7 @@ Helm chart. Let's pull down the chart so that we can get
 started.
 
 ```bash
-helm pull oci://registry-1.docker.io/bitnamicharts/harbor --untar
+helm pull --version 16.6.8 oci://registry-1.docker.io/bitnamicharts/harbor --untar
 ```
 
 Let's also set up our shell for interacting with the Replicated

--- a/instruqt/distributing-with-replicated/01-preparing-to-use-the-sdk/solve-shell
+++ b/instruqt/distributing-with-replicated/01-preparing-to-use-the-sdk/solve-shell
@@ -17,4 +17,4 @@ fi
 
 tmux send-keys -t shell export SPACE 'REPLICATED_API_TOKEN=' "$(agent variable get REPLICATED_API_TOKEN)" ENTER
 tmux send-keys -t shell export SPACE 'REPLICATED_APP=' "$(agent variable get REPLICATED_APP)" ENTER
-tmux send-keys -t shell 'helm pull oci://registry-1.docker.io/bitnamicharts/harbor --untar' ENTER
+tmux send-keys -t shell 'helm pull --version 16.6.8 oci://registry-1.docker.io/bitnamicharts/harbor --untar' ENTER


### PR DESCRIPTION
TLDR
=====
Pinning Harbor version to maintain lab version bumps

Description
====
Modified the `helm pull` command to use `helm pull --version` when pulling Harbor. This ensures that as Harbor is updated, the lab does not need to change to reflect Harbor versioning.