### PR TITLE
Addresses pre-Kubecon feedback from Marketing

### DIFF
--- a/instruqt/avoiding-installation-pitfalls/01-working-with-preflight-checks/assignment.md
+++ b/instruqt/avoiding-installation-pitfalls/01-working-with-preflight-checks/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: working-with-preflight-checks
-id: hbegc1xc0kld
+id: wws3xzj7kocw
 type: challenge
 title: Working with Preflight Checks
 teaser: |-

--- a/instruqt/avoiding-installation-pitfalls/01-working-with-preflight-checks/assignment.md
+++ b/instruqt/avoiding-installation-pitfalls/01-working-with-preflight-checks/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: working-with-preflight-checks
-id: wws3xzj7kocw
+id: vas7h6ypnrmy
 type: challenge
 title: Working with Preflight Checks
 teaser: |-
@@ -16,7 +16,7 @@ tabs:
 - title: Manifest Editor
   type: code
   hostname: shell
-  path: /home/replicant
+  path: /home
 difficulty: basic
 timelimit: 300
 ---

--- a/instruqt/avoiding-installation-pitfalls/02-checking-cluster-resources/assignment.md
+++ b/instruqt/avoiding-installation-pitfalls/02-checking-cluster-resources/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: checking-cluster-resources
-id: ghsphablorib
+id: 6yqtivyn9sjj
 type: challenge
 title: Checking Cluster Resources
 teaser: Use preflight checks to validate minimum cluster requirements

--- a/instruqt/avoiding-installation-pitfalls/02-checking-cluster-resources/assignment.md
+++ b/instruqt/avoiding-installation-pitfalls/02-checking-cluster-resources/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: checking-cluster-resources
-id: 6yqtivyn9sjj
+id: fjch1mlffnx4
 type: challenge
 title: Checking Cluster Resources
 teaser: Use preflight checks to validate minimum cluster requirements

--- a/instruqt/avoiding-installation-pitfalls/03-adding-preflights-to-the-chart/assignment.md
+++ b/instruqt/avoiding-installation-pitfalls/03-adding-preflights-to-the-chart/assignment.md
@@ -228,12 +228,12 @@ helm template harbor | kubectl preflight -
 ```
 
 If you're satisfied with the tests, bump the version of your Helm chart in the file
-`harbor/Chart.yaml` from `16.7.0` to `16.8.0`, then repackage it. You can edit
+`harbor/Chart.yaml` from `19.2.0` to `19.3.0`, then repackage it. You can edit
 the version in the Manifest Editor or run the following command to do it from
 the shell:
 
 ```
-yq -i '.version = "16.8.0"' harbor/Chart.yaml
+yq -i '.version = "19.3.0"' harbor/Chart.yaml
 ```
 
 Then run the `helm package` command to package the updated version:

--- a/instruqt/avoiding-installation-pitfalls/03-adding-preflights-to-the-chart/assignment.md
+++ b/instruqt/avoiding-installation-pitfalls/03-adding-preflights-to-the-chart/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: adding-preflights-to-the-chart
-id: rey80xsp7n5p
+id: h1alw68r1tr3
 type: challenge
 title: Adding Preflights to the Harbor Helm Chart
 teaser: Learn how to incorporate your preflight checks into your chart

--- a/instruqt/avoiding-installation-pitfalls/03-adding-preflights-to-the-chart/assignment.md
+++ b/instruqt/avoiding-installation-pitfalls/03-adding-preflights-to-the-chart/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: adding-preflights-to-the-chart
-id: h1alw68r1tr3
+id: lcpwe2dkxmr0
 type: challenge
 title: Adding Preflights to the Harbor Helm Chart
 teaser: Learn how to incorporate your preflight checks into your chart

--- a/instruqt/avoiding-installation-pitfalls/03-adding-preflights-to-the-chart/check-shell
+++ b/instruqt/avoiding-installation-pitfalls/03-adding-preflights-to-the-chart/check-shell
@@ -44,7 +44,7 @@ if [[ "${fails}" -ne "1" ]] ; then
 fi
 
 # look for the preflight template file
-if [[ ! -f /home/replicant/release/harbor-16.8.0.tgz ]] ; then
+if [[ ! -f /home/replicant/release/harbor-19.3.0.tgz ]] ; then
   fail-message $'Please make sure you\'ve bumped the version of your Helm chart and re-packaged it'
   let "result = result + 1"
 fi

--- a/instruqt/avoiding-installation-pitfalls/03-adding-preflights-to-the-chart/solve-shell
+++ b/instruqt/avoiding-installation-pitfalls/03-adding-preflights-to-the-chart/solve-shell
@@ -86,6 +86,6 @@ stringData:
                   message: Your cluster has sufficient memory available to run Harbor
 HARBOR_PREFLIGHTS
 
-yq -i '.version = "16.8.0"' /home/replicant/harbor/Chart.yaml
+yq -i '.version = "19.3.0"' /home/replicant/harbor/Chart.yaml
 helm package /home/replicant/harbor --destination /home/replicant/release
 chown -R replicant /home/replicant/harbor /home/replicant/release

--- a/instruqt/avoiding-installation-pitfalls/04-releasing-the-application/assignment.md
+++ b/instruqt/avoiding-installation-pitfalls/04-releasing-the-application/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: releasing-the-application
-id: ivm88bvvie5l
+id: 0vyspwc60kxh
 type: challenge
 title: Releasing the Application
 teaser: Releasing with preflights on the Replicated Platform

--- a/instruqt/avoiding-installation-pitfalls/04-releasing-the-application/assignment.md
+++ b/instruqt/avoiding-installation-pitfalls/04-releasing-the-application/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: releasing-the-application
-id: 0vyspwc60kxh
+id: 5jisluk3n6vr
 type: challenge
 title: Releasing the Application
 teaser: Releasing with preflights on the Replicated Platform

--- a/instruqt/avoiding-installation-pitfalls/04-releasing-the-application/assignment.md
+++ b/instruqt/avoiding-installation-pitfalls/04-releasing-the-application/assignment.md
@@ -88,7 +88,7 @@ use the `Unstable` channel for this lab, since the latter
 approach is best for teams working with feature branches.
 
 ```
-replicated release create --promote Unstable --yaml-dir ./release --version 19.3.0  \
+replicated release create --promote Unstable --chart ./release/harbor-19.3.0.tgz --version 19.3.0  \
   --release-notes "Adds preflight checks to enable customers to validate cluster prerequisites before installing"
 ```
 

--- a/instruqt/avoiding-installation-pitfalls/04-releasing-the-application/assignment.md
+++ b/instruqt/avoiding-installation-pitfalls/04-releasing-the-application/assignment.md
@@ -88,11 +88,11 @@ use the `Unstable` channel for this lab, since the latter
 approach is best for teams working with feature branches.
 
 ```
-replicated release create --promote Unstable --yaml-dir ./release --version 16.8.0  \
+replicated release create --promote Unstable --yaml-dir ./release --version 19.3.0  \
   --release-notes "Adds preflight checks to enable customers to validate cluster prerequisites before installing"
 ```
 
-This creates a release for version `16.8.0` of the Harbor Helm
+This creates a release for version `19.3.0` of the Harbor Helm
 chart, and promotes it to the `Unstable` channel. The `create`
 command output a sequence number that you'll need for `promote` (it
 will be `2` if you haven't explored releasing a bit more).
@@ -112,14 +112,14 @@ of those channels---your teams review and approval processes,
 steps in a continuous delivery pipeline, or both. Run the following command to promote our release to the `Beta` channel:
 
 ```
-replicated release promote 2 Beta --version 16.8.0 \
+replicated release promote 2 Beta --version 19.3.0 \
   --release-notes "Adds preflight checks to enable customers to validate cluster prerequisites before installing"
 ```
 
 Then promote to the `Stable` channel:
 
 ```
-replicated release promote 2 Stable --version 16.8.0 \
+replicated release promote 2 Stable --version 19.3.0 \
   --release-notes "Adds preflight checks to enable customers to validate cluster prerequisites before installing"
 ```
 

--- a/instruqt/avoiding-installation-pitfalls/04-releasing-the-application/check-shell
+++ b/instruqt/avoiding-installation-pitfalls/04-releasing-the-application/check-shell
@@ -9,22 +9,22 @@ result=0
 # check for release to Unstable
 api_token=$(get_api_token)
 unstable_version=$(curl --header "Accept: application/json" --header "Authorization: ${api_token}" https://api.replicated.com/vendor/v3/apps | jq -r '.apps[0].channels[] | select( .name == "Unstable" ) | .currentVersion')
-if [[ ! "${unstable_version}" == "16.8.0"  ]] ; then
-  fail-message $'Please be sure to release the applicaton to the \`Unstable\` channel with version \`16.8.0\`'
+if [[ ! "${unstable_version}" == "19.3.0"  ]] ; then
+  fail-message $'Please be sure to release the applicaton to the \`Unstable\` channel with version \`19.3.0\`'
   let "result = result + 1"
 fi
 
 # check for promotion to Beta
 beta_version=$(curl --header "Accept: application/json" --header "Authorization: ${api_token}" https://api.replicated.com/vendor/v3/apps | jq -r '.apps[0].channels[] | select( .name == "Beta" ) | .currentVersion')
-if [[ ! "${beta_version}" == "16.8.0"  ]] ; then
-  fail-message $'Please be sure to promote the applicaton to the \`Beta\` channel with version \`16.8.0\`'
+if [[ ! "${beta_version}" == "19.3.0"  ]] ; then
+  fail-message $'Please be sure to promote the applicaton to the \`Beta\` channel with version \`19.3.0\`'
   let "result = result + 1"
 fi
 
 # check for promotion to Stable
 stable_version=$(curl --header "Accept: application/json" --header "Authorization: ${api_token}" https://api.replicated.com/vendor/v3/apps | jq -r '.apps[0].channels[] | select( .name == "Stable" ) | .currentVersion')
-if [[ ! "${stable_version}" == "16.8.0"  ]] ; then
-  fail-message $'Please be sure to promote the applicaton to the \`Stable\` channel with version \`16.8.0\`'
+if [[ ! "${stable_version}" == "19.3.0"  ]] ; then
+  fail-message $'Please be sure to promote the applicaton to the \`Stable\` channel with version \`19.3.0\`'
   let "result = result + 1"
 fi
 

--- a/instruqt/avoiding-installation-pitfalls/04-releasing-the-application/solve-shell
+++ b/instruqt/avoiding-installation-pitfalls/04-releasing-the-application/solve-shell
@@ -29,7 +29,7 @@ api_token=$(get_api_token)
 app_slug=$(curl --header "Accept: application/json" --header "Authorization: ${api_token}" https://api.replicated.com/vendor/v3/apps | jq -r '.apps[0].slug')
 
 # release to the `Unstable` channel
-replicated release create --promote Unstable --yaml-dir /home/replicant/release --version 16.8.0 \
+replicated release create --promote Unstable --yaml-dir /home/replicant/release --version 19.3.0 \
   --release-notes "Adds preflight checks to enable customers to validate cluster prerequisites before installing" \
   --app ${app_slug} --token ${api_token}
 
@@ -37,11 +37,11 @@ replicated release create --promote Unstable --yaml-dir /home/replicant/release 
 release_sequence=$(curl --header "Accept: application/json" --header "Authorization: ${api_token}" https://api.replicated.com/vendor/v3/apps | jq -r '.apps[0].channels[] | select( .name == "Unstable" ) | .releaseSequence')
 
 # promote to the `Beta` channel
-replicated release promote ${release_sequence} Beta --version 16.8.0 \
+replicated release promote ${release_sequence} Beta --version 19.3.0 \
   --release-notes "Adds preflight checks to enable customers to validate cluster prerequisites before installing" \
   --app ${app_slug} --token ${api_token}
  
 # promote to the `Stable` channel
-replicated release promote ${release_sequence} Stable --version 16.8.0 \
+replicated release promote ${release_sequence} Stable --version 19.3.0 \
   --release-notes "Adds preflight checks to enable customers to validate cluster prerequisites before installing" \
   --app ${app_slug} --token ${api_token}

--- a/instruqt/avoiding-installation-pitfalls/04-releasing-the-application/solve-shell
+++ b/instruqt/avoiding-installation-pitfalls/04-releasing-the-application/solve-shell
@@ -29,7 +29,7 @@ api_token=$(get_api_token)
 app_slug=$(curl --header "Accept: application/json" --header "Authorization: ${api_token}" https://api.replicated.com/vendor/v3/apps | jq -r '.apps[0].slug')
 
 # release to the `Unstable` channel
-replicated release create --promote Unstable --yaml-dir /home/replicant/release --version 19.3.0 \
+replicated release create --promote Unstable --chart ./release/harbor-19.3.0.tgz --version 19.3.0  \
   --release-notes "Adds preflight checks to enable customers to validate cluster prerequisites before installing" \
   --app ${app_slug} --token ${api_token}
 

--- a/instruqt/avoiding-installation-pitfalls/05-validating-before-an-install/assignment.md
+++ b/instruqt/avoiding-installation-pitfalls/05-validating-before-an-install/assignment.md
@@ -44,7 +44,7 @@ Password: `[[ Instruqt-Var key="PASSWORD" hostname="shell" ]]`
 
 You'll land on the "Channels" page for your app, which will show
 the release channels we discussed in the previous step. Notice that
-each of the default channels shows the current version `16.8.0`,
+each of the default channels shows the current version `19.3.0`,
 while the channel LTS, which we haven't released to, reflects
 that.
 

--- a/instruqt/avoiding-installation-pitfalls/05-validating-before-an-install/assignment.md
+++ b/instruqt/avoiding-installation-pitfalls/05-validating-before-an-install/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: validating-before-an-install
-id: agnr2vn44qs0
+id: xwfh1tvi7wyq
 type: challenge
 title: Validating Before an Install
 teaser: How your customer uses preflights to validate their environment

--- a/instruqt/avoiding-installation-pitfalls/05-validating-before-an-install/assignment.md
+++ b/instruqt/avoiding-installation-pitfalls/05-validating-before-an-install/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: validating-before-an-install
-id: xwfh1tvi7wyq
+id: gyzywxla7qt8
 type: challenge
 title: Validating Before an Install
 teaser: How your customer uses preflights to validate their environment

--- a/instruqt/avoiding-installation-pitfalls/05-validating-before-an-install/solve-shell
+++ b/instruqt/avoiding-installation-pitfalls/05-validating-before-an-install/solve-shell
@@ -14,7 +14,7 @@ app_slug=$(curl --header 'Accept: application/json' --header "Authorization: ${a
 customer_email="${INSTRUQT_PARTICIPANT_ID}@geeglo.io"
 
 # create the new customer and keep track of the ID
-customer_id=$(replicated customer create --name "Geeglo" --email ${customer_email} --channel Stable --expires-in 720h --output json --app ${app_slug} --token ${api_token} | jq -r .id)
+customer_id=$(replicated customer create --name "Geeglo" --email ${customer_email} --channel Stable --expires-in 720h --kots-install=false --output json --app ${app_slug} --token ${api_token} | jq -r .id)
 
 # make sure the customer has a trial license
 updated_customer=$(curl --header 'Accept: application/json' --header "Authorization: ${api_token}" "https://api.replicated.com/vendor/v3/app/${app_id}/customer/${customer_id}" | \

--- a/instruqt/avoiding-installation-pitfalls/06-completing-the-install/assignment.md
+++ b/instruqt/avoiding-installation-pitfalls/06-completing-the-install/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: completing-the-install
-id: aeywtcz1jfwc
+id: wxzapo6eqzrv
 type: challenge
 title: Completing the Install
 teaser: Finishing the install once the cluster passes its preflights

--- a/instruqt/avoiding-installation-pitfalls/06-completing-the-install/assignment.md
+++ b/instruqt/avoiding-installation-pitfalls/06-completing-the-install/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: completing-the-install
-id: wxzapo6eqzrv
+id: 3fqiqvosmf7i
 type: challenge
 title: Completing the Install
 teaser: Finishing the install once the cluster passes its preflights

--- a/instruqt/avoiding-installation-pitfalls/06-completing-the-install/check-shell
+++ b/instruqt/avoiding-installation-pitfalls/06-completing-the-install/check-shell
@@ -8,7 +8,7 @@ result=0
 
 # check for release to Unstable
 installed_chart=$(helm list -o yaml --kubeconfig /home/replicant/.kube/config | yq '.[0].chart')
-if [[ ! "${installed_chart}" == "harbor-16.8.0"  ]] ; then
+if [[ ! "${installed_chart}" == "harbor-19.3.0"  ]] ; then
   fail-message 'Please be sure to install the Harbor Helm chart'
   let "result = result + 1"
 fi

--- a/instruqt/avoiding-installation-pitfalls/config.yml
+++ b/instruqt/avoiding-installation-pitfalls/config.yml
@@ -1,7 +1,7 @@
 version: "3"
 containers:
 - name: shell
-  image: gcr.io/kots-field-labs/shell:feature-helm-preflights
+  image: gcr.io/kots-field-labs/shell:main
   shell: tmux new-session -A -s shell su - replicant
 virtualmachines:
 - name: cluster

--- a/instruqt/avoiding-installation-pitfalls/track.yml
+++ b/instruqt/avoiding-installation-pitfalls/track.yml
@@ -31,4 +31,4 @@ lab_config:
   width: 33
   position: right
   enableLoadingMessages: true
-checksum: "1146789211619918110"
+checksum: "15041863163879828350"

--- a/instruqt/avoiding-installation-pitfalls/track.yml
+++ b/instruqt/avoiding-installation-pitfalls/track.yml
@@ -30,4 +30,5 @@ lab_config:
   overlay: false
   width: 33
   position: right
-checksum: "10581743701734031394"
+  enableLoadingMessages: true
+checksum: "1146789211619918110"

--- a/instruqt/avoiding-installation-pitfalls/track.yml
+++ b/instruqt/avoiding-installation-pitfalls/track.yml
@@ -1,5 +1,5 @@
 slug: avoiding-installation-pitfalls
-id: 
+id: amjfqroa5bfk
 title: Avoiding Installation Pitfalls
 teaser: |-
   Use Preflight checks to avoid common installation pitfalls
@@ -19,16 +19,15 @@ description: |-
      installing
 icon: https://storage.googleapis.com/shared-lab-assets/icons/red/checklist.png
 tags:
-- builders-plan
-- helm
-- troubleshoot
 - prod
+- builders-plan
+- troubleshoot
+- helm
 owner: replicated
 developers:
 - chuck@replicated.com
-maintenance: false
 lab_config:
   overlay: false
   width: 33
   position: right
-checksum: "18363644782998677466"
+checksum: "10581743701734031394"

--- a/instruqt/avoiding-installation-pitfalls/track_scripts/setup-shell
+++ b/instruqt/avoiding-installation-pitfalls/track_scripts/setup-shell
@@ -30,9 +30,10 @@ export REPLICATED_API_TOKEN=${api_token}
 export REPLICATED_APP=${app_slug}
 
 cd /home/replicant
-mkdir release
-helm pull --version 16.6.8 oci://registry-1.docker.io/bitnamicharts/harbor --untar
-yq -i '.version = "16.7.0"' harbor/Chart.yaml
+mkdir /home/replicant/release
+
+helm pull --version 19.1.0 oci://registry-1.docker.io/bitnamicharts/harbor --untar
+yq -i '.version = "19.2.0"' harbor/Chart.yaml
 replicated_sdk_version=$(curl -qsfL https://api.github.com/repos/replicatedhq/replicated-sdk/tags | jq -r '.[0] | .name')
 yq -i ".dependencies += { \"name\": \"replicated\", \"repository\": \"oci://registry.replicated.com/library\", \"version\": \"${replicated_sdk_version#?}\"}" harbor/Chart.yaml
 
@@ -45,7 +46,7 @@ helm package harbor --destination release
 # release and promote the app
 
 # release to the `Unstable` channel
-replicated release create --promote Unstable --yaml-dir /home/replicant/release --version 16.7.0 \
+replicated release create --promote Unstable --yaml-dir /home/replicant/release --version 19.2.0 \
   --release-notes "Prepares for distribution with Replicated by incorporating the Replicated SDK" \
   --app ${app_slug} --token ${api_token}
 
@@ -53,12 +54,12 @@ replicated release create --promote Unstable --yaml-dir /home/replicant/release 
 release_sequence=$(curl --header "Accept: application/json" --header "Authorization: ${api_token}" https://api.replicated.com/vendor/v3/apps | jq -r '.apps[0].channels[] | select( .name == "Unstable" ) | .releaseSequence')
 
 # promote to the `Beta` channel
-replicated release promote ${release_sequence} Beta --version 16.7.0 \
+replicated release promote ${release_sequence} Beta --version 19.2.0 \
   --release-notes "Prepares for distribution with Replicated by incorporating the Replicated SDK" \
   --app ${app_slug} --token ${api_token}
  
 # promote to the `Stable` channel
-replicated release promote ${release_sequence} Stable --version 16.7.0 \
+replicated release promote ${release_sequence} Stable --version 19.2.0 \
   --release-notes "Prepares for distribution with Replicated by incorporating the Replicated SDK" \
   --app ${app_slug} --token ${api_token}
 
@@ -67,7 +68,7 @@ replicated channel create --name LTS --description "Releases with long-term supp
   --app ${app_slug} --token ${api_token}
 
 # remove the helm chart we used to create the release
-rm /home/replicant/release/harbor-16.7.0.tgz
+rm /home/replicant/release/harbor-19.2.0.tgz
 
 # make sure permissions are good
 chown -R replicant /home/replicant/harbor /home/replicant/release

--- a/instruqt/avoiding-installation-pitfalls/track_scripts/setup-shell
+++ b/instruqt/avoiding-installation-pitfalls/track_scripts/setup-shell
@@ -46,7 +46,7 @@ helm package harbor --destination release
 # release and promote the app
 
 # release to the `Unstable` channel
-replicated release create --promote Unstable --yaml-dir /home/replicant/release --version 19.2.0 \
+replicated release create --promote Unstable --chart /home/replicant/release/harbor-19.2.0.tgz --version 19.2.0 \
   --release-notes "Prepares for distribution with Replicated by incorporating the Replicated SDK" \
   --app ${app_slug} --token ${api_token}
 

--- a/instruqt/closing-information-gap/01-viewing-instance-info/assignment.md
+++ b/instruqt/closing-information-gap/01-viewing-instance-info/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: viewing-instance-info
-id: jn2jgj1wc3e2
+id: jukpqxmfyyww
 type: challenge
 title: Getting a Picture of a Customer Instance
 teaser: Using the Replicated Platform to understand details of a customer instance

--- a/instruqt/closing-information-gap/01-viewing-instance-info/assignment.md
+++ b/instruqt/closing-information-gap/01-viewing-instance-info/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: viewing-instance-info
-id: u7arnjksadrw
+id: jn2jgj1wc3e2
 type: challenge
 title: Getting a Picture of a Customer Instance
 teaser: Using the Replicated Platform to understand details of a customer instance

--- a/instruqt/closing-information-gap/01-viewing-instance-info/check-shell
+++ b/instruqt/closing-information-gap/01-viewing-instance-info/check-shell
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# This set line ensures that all failures will cause the script to error and exit
+set -euxo pipefail
+exit 0

--- a/instruqt/closing-information-gap/02-working-with-support-bundles/assignment.md
+++ b/instruqt/closing-information-gap/02-working-with-support-bundles/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: working-with-support-bundles
-id: yoaffx6a7m6t
+id: toucvosxrmfv
 type: challenge
 title: Working with Support Bundles
 teaser: |-
@@ -58,7 +58,7 @@ spec:
 ```
 
 You can view the file in the Manifest Editor tab or from the command line.
-Let's try colelcting a support bunglde with it..
+Let's try collecting a support bunglde with it.
 
 ```
 kubectl support-bundle ./simplest-support-bundle.yaml

--- a/instruqt/closing-information-gap/02-working-with-support-bundles/assignment.md
+++ b/instruqt/closing-information-gap/02-working-with-support-bundles/assignment.md
@@ -16,7 +16,7 @@ tabs:
 - title: Manifest Editor
   type: code
   hostname: shell
-  path: /home/replicant
+  path: /home
 difficulty: basic
 timelimit: 420
 ---

--- a/instruqt/closing-information-gap/02-working-with-support-bundles/assignment.md
+++ b/instruqt/closing-information-gap/02-working-with-support-bundles/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: working-with-support-bundles
-id: y9cpyp05iq1k
+id: yoaffx6a7m6t
 type: challenge
 title: Working with Support Bundles
 teaser: |-

--- a/instruqt/closing-information-gap/03-additional-information/assignment.md
+++ b/instruqt/closing-information-gap/03-additional-information/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: additional-information
-id: s124teq511sr
+id: 9nq6zzdmcawq
 type: challenge
 title: Collecting and Analyzing Additional Information
 teaser: |

--- a/instruqt/closing-information-gap/03-additional-information/assignment.md
+++ b/instruqt/closing-information-gap/03-additional-information/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: additional-information
-id: sxl90k6n2bmz
+id: s124teq511sr
 type: challenge
 title: Collecting and Analyzing Additional Information
 teaser: |

--- a/instruqt/closing-information-gap/04-adding-to-the-chart/assignment.md
+++ b/instruqt/closing-information-gap/04-adding-to-the-chart/assignment.md
@@ -129,12 +129,12 @@ Repackaging Your Chart
 ======================
 
 To distribute your support bundle, you should bump the version number in
-`harbor/Chart.yaml` (from `19.3.0` to `16.9.0`) adn then repackage it. You can edit
+`harbor/Chart.yaml` (from `19.3.0` to `19.4.0`) adn then repackage it. You can edit
 the version in the Manifest Editor or run the following command to do it from
 the shell.
 
 ```
-yq -i '.version = "16.9.0"' harbor/Chart.yaml
+yq -i '.version = "19.4.0"' harbor/Chart.yaml
 ```
 
 and run the `helm package` command to package the updated version

--- a/instruqt/closing-information-gap/04-adding-to-the-chart/assignment.md
+++ b/instruqt/closing-information-gap/04-adding-to-the-chart/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: adding-to-the-chart
-id: eyurng2zyce6
+id: 5gjk0ex2xofz
 type: challenge
 title: Adding the Support Bundle to the Harbor Helm Chart
 teaser: Learn how to incorporate your support bundle into your chart

--- a/instruqt/closing-information-gap/04-adding-to-the-chart/assignment.md
+++ b/instruqt/closing-information-gap/04-adding-to-the-chart/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: adding-to-the-chart
-id: vvxrunt3e7zu
+id: eyurng2zyce6
 type: challenge
 title: Adding the Support Bundle to the Harbor Helm Chart
 teaser: Learn how to incorporate your support bundle into your chart
@@ -129,7 +129,7 @@ Repackaging Your Chart
 ======================
 
 To distribute your support bundle, you should bump the version number in
-`harbor/Chart.yaml` (from `16.8.0` to `16.9.0`) adn then repackage it. You can edit
+`harbor/Chart.yaml` (from `19.3.0` to `16.9.0`) adn then repackage it. You can edit
 the version in the Manifest Editor or run the following command to do it from
 the shell.
 

--- a/instruqt/closing-information-gap/04-adding-to-the-chart/check-shell
+++ b/instruqt/closing-information-gap/04-adding-to-the-chart/check-shell
@@ -11,11 +11,11 @@ if [[ ! -f /home/replicant/harbor/templates/troubleshoot/support-bundle.yaml ]] 
   let "result = result + 1"
 fi
 
-if [[ "$(helm template /home/replicant/harbor | yq 'select( .kind == "Secret" ) | select( .metadata.labels."troubleshoot.sh/kind" == "support-bundle" ) | .stringData | has("support-bundle-spec")')" == "true" ]] ; then
+if [[ "$(helm template /home/replicant/harbor | yq 'select( .kind == "Secret" ) | select( .metadata.labels."troubleshoot.sh/kind" == "support-bundle" ) | .stringData | has("support-bundle-spec")' | head -1)" == "true" ]] ; then
   set +e pipefail
   analyzer_results="$(helm template /home/replicant/harbor | kubectl support-bundle --interactive=false --kubeconfig /home/replicant/.kube/config -)"
   set -e pipefail
 else
-  fail-message 'Please add your preflight checks to the preflights template file'
+  fail-message 'Please add your support bundle definition to the support bundle template file'
   let "result = result + 1"
 fi

--- a/instruqt/closing-information-gap/04-adding-to-the-chart/solve-shell
+++ b/instruqt/closing-information-gap/04-adding-to-the-chart/solve-shell
@@ -3,7 +3,7 @@
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
 
-cat <<HARBOR_SUPPORT_BUNDLE > /home/replicant/harbor/templates/support-bundle.yaml
+cat <<HARBOR_SUPPORT_BUNDLE > /home/replicant/harbor/templates/troubelshoot/support-bundle.yaml
 apiVersion: v1
 kind: Secret
 metadata:

--- a/instruqt/closing-information-gap/04-adding-to-the-chart/solve-shell
+++ b/instruqt/closing-information-gap/04-adding-to-the-chart/solve-shell
@@ -221,6 +221,6 @@ stringData:
                     The Trivy image scanner is running on this cluster and ready for use.
 HARBOR_SUPPORT_BUNDLE
 
-yq -i '.version = "16.9.0"' /home/replicant/harbor/Chart.yaml
+yq -i '.version = "19.4.0"' /home/replicant/harbor/Chart.yaml
 helm package /home/replicant/harbor --destination /home/replicant/release
 chown -R replicant /home/replicant/harbor /home/replicant/release

--- a/instruqt/closing-information-gap/05-releasing-an-update/assignment.md
+++ b/instruqt/closing-information-gap/05-releasing-an-update/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: releasing-an-update
-id: phzx2xp3gdbp
+id: ojdf6ltz8t6t
 type: challenge
 title: Releasing an Update with the Support Bundle
 teaser: Releasing a new version with the support bundle included

--- a/instruqt/closing-information-gap/05-releasing-an-update/assignment.md
+++ b/instruqt/closing-information-gap/05-releasing-an-update/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: releasing-an-update
-id: tnyktndlfuw7
+id: phzx2xp3gdbp
 type: challenge
 title: Releasing an Update with the Support Bundle
 teaser: Releasing a new version with the support bundle included

--- a/instruqt/closing-information-gap/05-releasing-an-update/assignment.md
+++ b/instruqt/closing-information-gap/05-releasing-an-update/assignment.md
@@ -72,7 +72,7 @@ default release channels that is generally used internally for releases that
 may or not be ready for customers.
 
 ```
-replicated release create --promote Unstable --yaml-dir ./release --version 19.4.0  \
+replicated release create --promote Unstable --chart ./release/harbor-19.4.0.tgz --version 19.4.0  \
   --release-notes "Adds a support bundle spec to facilitate troubleshooting"
 ```
 

--- a/instruqt/closing-information-gap/05-releasing-an-update/assignment.md
+++ b/instruqt/closing-information-gap/05-releasing-an-update/assignment.md
@@ -72,11 +72,11 @@ default release channels that is generally used internally for releases that
 may or not be ready for customers.
 
 ```
-replicated release create --promote Unstable --yaml-dir ./release --version 16.9.0  \
+replicated release create --promote Unstable --yaml-dir ./release --version 19.4.0  \
   --release-notes "Adds a support bundle spec to facilitate troubleshooting"
 ```
 
-This creates a release for version `16.9.0` of the Harbor Helm chart, and
+This creates a release for version `19.4.0` of the Harbor Helm chart, and
 promotes it to the `Unstable` channel. The `create` command output sequence
 number that you'll need for `promote` (it will be `3` if you haven't explored
 releasing a bit more).
@@ -122,14 +122,14 @@ to determine whether a release should be promoted to each of those
 channels---hopefully automated as part of your continuous delivery pipelines.
 
 ```
-replicated release promote 3 Beta --version 16.9.0 \
+replicated release promote 3 Beta --version 19.4.0 \
   --release-notes "Adds a support bundle spec to facilitate troubleshooting"
 ```
 
 and then
 
 ```
-replicated release promote 3 Stable --version 16.9.0 \
+replicated release promote 3 Stable --version 19.4.0 \
   --release-notes "Adds a support bundle spec to facilitate troubleshooting"
 ```
 

--- a/instruqt/closing-information-gap/05-releasing-an-update/check-shell
+++ b/instruqt/closing-information-gap/05-releasing-an-update/check-shell
@@ -9,22 +9,22 @@ result=0
 # check for release to Unstable
 api_token=$(get_api_token)
 unstable_version=$(curl --header "Accept: application/json" --header "Authorization: ${api_token}" https://api.replicated.com/vendor/v3/apps | jq -r '.apps[0].channels[] | select( .name == "Unstable" ) | .currentVersion')
-if [[ ! "${unstable_version}" == "16.9.0"  ]] ; then
-  fail-message $'Please be sure to release the applicaton to the \`Unstable\` channel with version \`16.9.0\`'
+if [[ ! "${unstable_version}" == "19.4.0"  ]] ; then
+  fail-message $'Please be sure to release the applicaton to the \`Unstable\` channel with version \`19.4.0\`'
   let "result = result + 1"
 fi
 
 # check for promotion to Beta
 beta_version=$(curl --header "Accept: application/json" --header "Authorization: ${api_token}" https://api.replicated.com/vendor/v3/apps | jq -r '.apps[0].channels[] | select( .name == "Beta" ) | .currentVersion')
-if [[ ! "${beta_version}" == "16.9.0"  ]] ; then
-  fail-message $'Please be sure to promote the applicaton to the \`Beta\` channel with version \`16.9.0\`'
+if [[ ! "${beta_version}" == "19.4.0"  ]] ; then
+  fail-message $'Please be sure to promote the applicaton to the \`Beta\` channel with version \`19.4.0\`'
   let "result = result + 1"
 fi
 
 # check for promotion to Stable
 stable_version=$(curl --header "Accept: application/json" --header "Authorization: ${api_token}" https://api.replicated.com/vendor/v3/apps | jq -r '.apps[0].channels[] | select( .name == "Stable" ) | .currentVersion')
-if [[ ! "${stable_version}" == "16.9.0"  ]] ; then
-  fail-message $'Please be sure to promote the applicaton to the \`Stable\` channel with version \`16.9.0\`'
+if [[ ! "${stable_version}" == "19.4.0"  ]] ; then
+  fail-message $'Please be sure to promote the applicaton to the \`Stable\` channel with version \`19.4.0\`'
   let "result = result + 1"
 fi
 

--- a/instruqt/closing-information-gap/05-releasing-an-update/solve-shell
+++ b/instruqt/closing-information-gap/05-releasing-an-update/solve-shell
@@ -29,7 +29,7 @@ api_token=$(get_api_token)
 app_slug=$(curl --header "Accept: application/json" --header "Authorization: ${api_token}" https://api.replicated.com/vendor/v3/apps | jq -r '.apps[0].slug')
 
 # release to the `Unstable` channel
-replicated release create --promote Unstable --yaml-dir /home/replicant/release --version 19.4.0 \
+replicated release create --promote Unstable --chart /home/replicant/release/harbor-19.4.0.tgz --version 19.4.0  \
   --release-notes "Adds a support bundle spec to facilitate troubleshooting" \
   --app ${app_slug} --token ${api_token}
 

--- a/instruqt/closing-information-gap/05-releasing-an-update/solve-shell
+++ b/instruqt/closing-information-gap/05-releasing-an-update/solve-shell
@@ -29,7 +29,7 @@ api_token=$(get_api_token)
 app_slug=$(curl --header "Accept: application/json" --header "Authorization: ${api_token}" https://api.replicated.com/vendor/v3/apps | jq -r '.apps[0].slug')
 
 # release to the `Unstable` channel
-replicated release create --promote Unstable --yaml-dir /home/replicant/release --version 16.9.0 \
+replicated release create --promote Unstable --yaml-dir /home/replicant/release --version 19.4.0 \
   --release-notes "Adds a support bundle spec to facilitate troubleshooting" \
   --app ${app_slug} --token ${api_token}
 
@@ -37,11 +37,11 @@ replicated release create --promote Unstable --yaml-dir /home/replicant/release 
 release_sequence=$(curl --header "Accept: application/json" --header "Authorization: ${api_token}" https://api.replicated.com/vendor/v3/apps | jq -r '.apps[0].channels[] | select( .name == "Unstable" ) | .releaseSequence')
 
 # promote to the `Beta` channel
-replicated release promote ${release_sequence} Beta --version 16.9.0 \
+replicated release promote ${release_sequence} Beta --version 19.4.0 \
   --release-notes "Adds a support bundle spec to facilitate troubleshooting" \
   --app ${app_slug} --token ${api_token}
  
 # promote to the `Stable` channel
-replicated release promote ${release_sequence} Stable --version 16.9.0 \
+replicated release promote ${release_sequence} Stable --version 19.4.0 \
   --release-notes "Adds a support bundle spec to facilitate troubleshooting" \
   --app ${app_slug} --token ${api_token}

--- a/instruqt/closing-information-gap/06-support-bundle-diagnosis/assignment.md
+++ b/instruqt/closing-information-gap/06-support-bundle-diagnosis/assignment.md
@@ -42,7 +42,7 @@ their instance.
 
 ```
 helm upgrade harbor \
-  oci://registry.replicated.com/[[ Instruqt-Var key="REPLICATED_APP" hostname="shell" ]]/harbor \
+  oci://registry.replicated.com/[[ Instruqt-Var key="REPLICATED_APP" hostname="shell" ]]/harbor
 ```
 
 Check to see if the support bundle secret has been created.

--- a/instruqt/closing-information-gap/06-support-bundle-diagnosis/assignment.md
+++ b/instruqt/closing-information-gap/06-support-bundle-diagnosis/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: support-bundle-diagnosis
-id: y5uwhsz4tiwj
+id: ko5ke8j1aoto
 type: challenge
 title: Using the Support Bundle to Diagnose the Issue
 teaser: Discover the cause of Geeglo's outage using a support bundle

--- a/instruqt/closing-information-gap/06-support-bundle-diagnosis/assignment.md
+++ b/instruqt/closing-information-gap/06-support-bundle-diagnosis/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: support-bundle-diagnosis
-id: ko5ke8j1aoto
+id: wddwnaxnvkue
 type: challenge
 title: Using the Support Bundle to Diagnose the Issue
 teaser: Discover the cause of Geeglo's outage using a support bundle

--- a/instruqt/closing-information-gap/06-support-bundle-diagnosis/check-shell
+++ b/instruqt/closing-information-gap/06-support-bundle-diagnosis/check-shell
@@ -9,7 +9,7 @@ result=0
 
 # check for installation of the updated chart
 installed_chart=$(helm list -o yaml --kubeconfig /home/replicant/.kube/config | yq '.[0].chart')
-if [[ ! "${installed_chart}" == "harbor-16.9.0"  ]] ; then
+if [[ ! "${installed_chart}" == "harbor-19.4.0"  ]] ; then
   fail-message $'Please be sure to upgrade the customer\'s instance to the verison including your support bundle'
   let "result = result + 1"
 fi

--- a/instruqt/closing-information-gap/06-support-bundle-diagnosis/setup-shell
+++ b/instruqt/closing-information-gap/06-support-bundle-diagnosis/setup-shell
@@ -31,4 +31,4 @@ registry_password=$(curl --header 'Accept: application/json' --header "Authoriza
   yq .customer.installationId) 
 
 agent variable set CUSTOMER_EMAIL ${customer_email}
-agent variable set REGISTRY_PASSWORD ${registry_pasword}
+agent variable set REGISTRY_PASSWORD ${registry_password}

--- a/instruqt/closing-information-gap/06-support-bundle-diagnosis/setup-shell
+++ b/instruqt/closing-information-gap/06-support-bundle-diagnosis/setup-shell
@@ -24,6 +24,7 @@ api_token=$(get_api_token)
 customer_email="${INSTRUQT_PARTICIPANT_ID}@geeglo.io"
 
 # get the registry password (which is the license id)
+app_id=$(curl --header 'Accept: application/json' --header "Authorization: ${api_token}" https://api.replicated.com/vendor/v3/apps | jq -r '.apps[0].id')
 registry_password=$(curl --header 'Accept: application/json' --header "Authorization: ${api_token}" "https://api.replicated.com/vendor/v3/app/${app_id}/customer/${customer_id}" | \
   yq .customer.installationId) 
 

--- a/instruqt/closing-information-gap/06-support-bundle-diagnosis/setup-shell
+++ b/instruqt/closing-information-gap/06-support-bundle-diagnosis/setup-shell
@@ -26,7 +26,7 @@ customer_email="${INSTRUQT_PARTICIPANT_ID}@geeglo.io"
 # get the registry password (which is the license id)
 app_id=$(curl --header 'Accept: application/json' --header "Authorization: ${api_token}" https://api.replicated.com/vendor/v3/apps | jq -r '.apps[0].id')
 app_slug=$(curl --header 'Accept: application/json' --header "Authorization: ${api_token}" https://api.replicated.com/vendor/v3/apps | jq -r '.apps[0].slug')
-customer_id=$(replicated customer ls --output json | jq -r '.[] | select ( .name == "Geeglo" ) | .id')
+customer_id=$(replicated customer ls --output json --app "${app_slug}" --token "${api_token}" | jq -r '.[] | select ( .name == "Geeglo" ) | .id')
 registry_password=$(curl --header 'Accept: application/json' --header "Authorization: ${api_token}" "https://api.replicated.com/vendor/v3/app/${app_id}/customer/${customer_id}" | \
   yq .customer.installationId) 
 

--- a/instruqt/closing-information-gap/06-support-bundle-diagnosis/setup-shell
+++ b/instruqt/closing-information-gap/06-support-bundle-diagnosis/setup-shell
@@ -25,6 +25,7 @@ customer_email="${INSTRUQT_PARTICIPANT_ID}@geeglo.io"
 
 # get the registry password (which is the license id)
 app_id=$(curl --header 'Accept: application/json' --header "Authorization: ${api_token}" https://api.replicated.com/vendor/v3/apps | jq -r '.apps[0].id')
+customer_id=$(replicated customer create --name "Geeglo" --email ${customer_email} --channel Stable --expires-in 720h --output json --app ${app_slug} --token ${api_token} | jq -r .id)
 registry_password=$(curl --header 'Accept: application/json' --header "Authorization: ${api_token}" "https://api.replicated.com/vendor/v3/app/${app_id}/customer/${customer_id}" | \
   yq .customer.installationId) 
 

--- a/instruqt/closing-information-gap/06-support-bundle-diagnosis/setup-shell
+++ b/instruqt/closing-information-gap/06-support-bundle-diagnosis/setup-shell
@@ -25,6 +25,7 @@ customer_email="${INSTRUQT_PARTICIPANT_ID}@geeglo.io"
 
 # get the registry password (which is the license id)
 app_id=$(curl --header 'Accept: application/json' --header "Authorization: ${api_token}" https://api.replicated.com/vendor/v3/apps | jq -r '.apps[0].id')
+app_slug=$(curl --header 'Accept: application/json' --header "Authorization: ${api_token}" https://api.replicated.com/vendor/v3/apps | jq -r '.apps[0].slug')
 customer_id=$(replicated customer create --name "Geeglo" --email ${customer_email} --channel Stable --expires-in 720h --output json --app ${app_slug} --token ${api_token} | jq -r .id)
 registry_password=$(curl --header 'Accept: application/json' --header "Authorization: ${api_token}" "https://api.replicated.com/vendor/v3/app/${app_id}/customer/${customer_id}" | \
   yq .customer.installationId) 

--- a/instruqt/closing-information-gap/06-support-bundle-diagnosis/setup-shell
+++ b/instruqt/closing-information-gap/06-support-bundle-diagnosis/setup-shell
@@ -26,7 +26,7 @@ customer_email="${INSTRUQT_PARTICIPANT_ID}@geeglo.io"
 # get the registry password (which is the license id)
 app_id=$(curl --header 'Accept: application/json' --header "Authorization: ${api_token}" https://api.replicated.com/vendor/v3/apps | jq -r '.apps[0].id')
 app_slug=$(curl --header 'Accept: application/json' --header "Authorization: ${api_token}" https://api.replicated.com/vendor/v3/apps | jq -r '.apps[0].slug')
-customer_id=$(replicated customer create --name "Geeglo" --email ${customer_email} --channel Stable --expires-in 720h --output json --app ${app_slug} --token ${api_token} | jq -r .id)
+customer_id=$(replicated customer ls --output json | jq -r '.[] | select ( .name == "Geeglo" ) | .id')
 registry_password=$(curl --header 'Accept: application/json' --header "Authorization: ${api_token}" "https://api.replicated.com/vendor/v3/app/${app_id}/customer/${customer_id}" | \
   yq .customer.installationId) 
 

--- a/instruqt/closing-information-gap/06-support-bundle-diagnosis/solve-shell
+++ b/instruqt/closing-information-gap/06-support-bundle-diagnosis/solve-shell
@@ -30,5 +30,5 @@ helm registry login registry.replicated.com \
 
 # upgrade the application
 app_slug=$(agent variable get REPLICATED_APP)
-helm upgrade harbor --version 16.9.0 \
+helm upgrade harbor --version 19.4.0 \
   oci://registry.replicated.com/${app_slug}/harbor \

--- a/instruqt/closing-information-gap/07-other-ways/assignment.md
+++ b/instruqt/closing-information-gap/07-other-ways/assignment.md
@@ -84,7 +84,7 @@ release sequence will be `5` unless you've played around with additional
 releases. If you have, use the current sequence.
 
 ```
-replicated release create --promote Unstable --yaml-dir ./release --version 19.4.1  \
+replicated release create --promote Unstable --chart ./release/harbor-19.4.1.tgz --version 19.4.1  \
   --release-notes "Provides the ability to upgrade the support bundle independent of the application"
 replicated release promote 4 Beta --version 19.4.1 \
   --release-notes "Provides the ability to upgrade the support bundle independent of the application"
@@ -100,6 +100,8 @@ new support bundle containing a reference to your independently released
 bundle.
 
 ```
+helm upgrade harbor \
+  oci://registry.replicated.com/[[ Instruqt-Var key="REPLICATED_APP" hostname="shell" ]]/harbor
 kubectl support-bundle --load-cluster-specs
 ```
 

--- a/instruqt/closing-information-gap/07-other-ways/assignment.md
+++ b/instruqt/closing-information-gap/07-other-ways/assignment.md
@@ -75,7 +75,7 @@ release directory. The following commands will take care of that for you.
 ```
 yq -i '.version = "16.9.1"' harbor/Chart.yaml
 helm package harbor --destination ./release
-rm ./release/harbor-16.9.0.tgz
+rm ./release/harbor-19.4.0.tgz
 ```
 
 Now you need to release your update and promote it. Remember that for a real

--- a/instruqt/closing-information-gap/07-other-ways/assignment.md
+++ b/instruqt/closing-information-gap/07-other-ways/assignment.md
@@ -67,13 +67,13 @@ Don't forget to the save the file.
 
 ![Adding a URI to the Support Bundle spec](../assets/adding-a-uri-to-the-spec.png)
 
-You should also bump the version number for the release to `16.9.1` in the
+You should also bump the version number for the release to `19.4.1` in the
 `Chart.yaml` file, repackage your chart, and delete the old tarball from your
 release directory. The following commands will take care of that for you.
 
 
 ```
-yq -i '.version = "16.9.1"' harbor/Chart.yaml
+yq -i '.version = "19.4.1"' harbor/Chart.yaml
 helm package harbor --destination ./release
 rm ./release/harbor-19.4.0.tgz
 ```
@@ -84,11 +84,11 @@ release sequence will be `5` unless you've played around with additional
 releases. If you have, use the current sequence.
 
 ```
-replicated release create --promote Unstable --yaml-dir ./release --version 16.9.1  \
+replicated release create --promote Unstable --yaml-dir ./release --version 19.4.1  \
   --release-notes "Provides the ability to upgrade the support bundle independent of the application"
-replicated release promote 5 Beta --version 16.9.1 \
+replicated release promote 4 Beta --version 19.4.1 \
   --release-notes "Provides the ability to upgrade the support bundle independent of the application"
-replicated release promote 5 Stable --version 16.9.1 \
+replicated release promote 4 Stable --version 19.4.1 \
   --release-notes "Provides the ability to upgrade the support bundle independent of the application"
 ```
 

--- a/instruqt/closing-information-gap/07-other-ways/assignment.md
+++ b/instruqt/closing-information-gap/07-other-ways/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: other-ways
-id: dfec8ytv6wmo
+id: zphzf0yxstck
 type: challenge
 title: Other Ways to Offer a Support Bundle
 teaser: Explore other ways to distibute your support bundle and keep it up to date

--- a/instruqt/closing-information-gap/07-other-ways/assignment.md
+++ b/instruqt/closing-information-gap/07-other-ways/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: other-ways
-id: zphzf0yxstck
+id: sr80rrntbsgo
 type: challenge
 title: Other Ways to Offer a Support Bundle
 teaser: Explore other ways to distibute your support bundle and keep it up to date

--- a/instruqt/closing-information-gap/07-other-ways/check-shell
+++ b/instruqt/closing-information-gap/07-other-ways/check-shell
@@ -14,28 +14,28 @@ fi
 # check for release to Unstable
 api_token=$(get_api_token)
 unstable_version=$(curl --header "Accept: application/json" --header "Authorization: ${api_token}" https://api.replicated.com/vendor/v3/apps | jq -r '.apps[0].channels[] | select( .name == "Unstable" ) | .currentVersion')
-if [[ ! "${unstable_version}" == "16.9.1"  ]] ; then
-  fail-message $'Please be sure to release the applicaton to the \`Unstable\` channel with version \`16.9.1\`'
+if [[ ! "${unstable_version}" == "19.4.1"  ]] ; then
+  fail-message $'Please be sure to release the applicaton to the \`Unstable\` channel with version \`19.4.1\`'
   let "result = result + 1"
 fi
 
 # check for promotion to Beta
 beta_version=$(curl --header "Accept: application/json" --header "Authorization: ${api_token}" https://api.replicated.com/vendor/v3/apps | jq -r '.apps[0].channels[] | select( .name == "Beta" ) | .currentVersion')
-if [[ ! "${beta_version}" == "16.9.1"  ]] ; then
-  fail-message $'Please be sure to promote the applicaton to the \`Beta\` channel with version \`16.9.1\`'
+if [[ ! "${beta_version}" == "19.4.1"  ]] ; then
+  fail-message $'Please be sure to promote the applicaton to the \`Beta\` channel with version \`19.4.1\`'
   let "result = result + 1"
 fi
 
 # check for promotion to Stable
 stable_version=$(curl --header "Accept: application/json" --header "Authorization: ${api_token}" https://api.replicated.com/vendor/v3/apps | jq -r '.apps[0].channels[] | select( .name == "Stable" ) | .currentVersion')
-if [[ ! "${stable_version}" == "16.9.1"  ]] ; then
-  fail-message $'Please be sure to promote the applicaton to the \`Stable\` channel with version \`16.9.1\`'
+if [[ ! "${stable_version}" == "19.4.1"  ]] ; then
+  fail-message $'Please be sure to promote the applicaton to the \`Stable\` channel with version \`19.4.1\`'
   let "result = result + 1"
 fi
 
 # check that the upgraade chart is installed
 installed_chart=$(helm list -o yaml --kubeconfig /home/replicant/.kube/config | yq '.[0].chart')
-if [[ ! "${installed_chart}" == "harbor-16.9.1"  ]] ; then
+if [[ ! "${installed_chart}" == "harbor-19.4.1"  ]] ; then
   fail-message $'Please be sure to upgrade the customer\'s instance to the verison including your updated support bundle'
   let "result = result + 1"
 fi

--- a/instruqt/closing-information-gap/07-other-ways/check-shell
+++ b/instruqt/closing-information-gap/07-other-ways/check-shell
@@ -3,11 +3,14 @@
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
 
+# convenience library for Replicated lab lifecycle scripts
+source /etc/profile.d/header.sh
+
 result=0
 
 # check whether the URI has been added to the spec
-uri_added=$(yq '.spec.has("uri")')
-if [[ "${uri_added}" ]] ; then
+uri_added=$(helm template /home/replicant/harbor | yq 'select( .kind == "Secret" ) | select( .metadata.labels."troubleshoot.sh/kind" == "support-bundle" ) | .stringData.support-bundle-spec | from_yaml | select ( .metadata.name == "harbor-support-bundle" ) | .spec | has("uri")')
+if [[ "${uri_added}" != "true" ]] ; then
   fail-message 'Please check your support bundle definition to make sure you added the uri for the updated bundle'
   let "result = result + 1"
 fi

--- a/instruqt/closing-information-gap/config.yml
+++ b/instruqt/closing-information-gap/config.yml
@@ -1,7 +1,7 @@
 version: "3"
 containers:
 - name: shell
-  image: gcr.io/kots-field-labs/shell:latest
+  image: gcr.io/kots-field-labs/shell:main
   shell: tmux new-session -A -s shell su - replicant
 virtualmachines:
 - name: cluster

--- a/instruqt/closing-information-gap/track.yml
+++ b/instruqt/closing-information-gap/track.yml
@@ -31,4 +31,4 @@ lab_config:
   width: 33
   position: right
   enableLoadingMessages: true
-checksum: "6412363109765968886"
+checksum: "16018974617273983350"

--- a/instruqt/closing-information-gap/track.yml
+++ b/instruqt/closing-information-gap/track.yml
@@ -1,5 +1,5 @@
 slug: closing-information-gap
-id: 
+id: hfb41xqkyx0q
 title: Closing the Support Information Gap
 teaser: |-
   Use the Replicated Platform to close the information gap between your
@@ -19,16 +19,15 @@ description: |-
      issue multiple times
 icon: https://storage.googleapis.com/shared-lab-assets/icons/red/audit_log.png
 tags:
-- builders-plan
-- helm
-- troubleshoot
 - prod
+- builders-plan
+- troubleshoot
+- helm
 owner: replicated
 developers:
 - chuck@replicated.com
-maintenance: false
 lab_config:
   overlay: false
   width: 33
   position: right
-checksum: "8657597645467563973"
+checksum: "11287051276948358833"

--- a/instruqt/closing-information-gap/track.yml
+++ b/instruqt/closing-information-gap/track.yml
@@ -31,4 +31,4 @@ lab_config:
   width: 33
   position: right
   enableLoadingMessages: true
-checksum: "15059399390332615665"
+checksum: "6412363109765968886"

--- a/instruqt/closing-information-gap/track.yml
+++ b/instruqt/closing-information-gap/track.yml
@@ -31,4 +31,4 @@ lab_config:
   width: 33
   position: right
   enableLoadingMessages: true
-checksum: "1984621493899880082"
+checksum: "15059399390332615665"

--- a/instruqt/closing-information-gap/track.yml
+++ b/instruqt/closing-information-gap/track.yml
@@ -30,4 +30,5 @@ lab_config:
   overlay: false
   width: 33
   position: right
-checksum: "11287051276948358833"
+  enableLoadingMessages: true
+checksum: "1984621493899880082"

--- a/instruqt/closing-information-gap/track_scripts/setup-shell
+++ b/instruqt/closing-information-gap/track_scripts/setup-shell
@@ -33,9 +33,10 @@ export REPLICATED_APP=${app_slug}
 
 ## release the application with the Replicated SDK
 cd /home/replicant
-mkdir release
-helm pull --version 16.6.8 oci://registry-1.docker.io/bitnamicharts/harbor --untar
-yq -i '.version = "16.7.0"' harbor/Chart.yaml
+mkdir /home/replicant/release
+
+helm pull --version 19.1.0 oci://registry-1.docker.io/bitnamicharts/harbor --untar
+yq -i '.version = "19.2.0"' harbor/Chart.yaml
 replicated_sdk_version=$(curl -qsfL https://api.github.com/repos/replicatedhq/replicated-sdk/tags | jq -r '.[0] | .name')
 yq -i ".dependencies += { \"name\": \"replicated\", \"repository\": \"oci://registry.replicated.com/library\", \"version\": \"${replicated_sdk_version#?}\"}" harbor/Chart.yaml
 
@@ -48,7 +49,7 @@ helm package harbor --destination release
 ## release and promote the app with the SDK added
 
 # release to the `Unstable` channel
-replicated release create --promote Unstable --yaml-dir /home/replicant/release --version 16.7.0 \
+replicated release create --promote Unstable --yaml-dir /home/replicant/release --version 19.2.0 \
   --release-notes "Prepares for distribution with Replicated by incorporating the Replicated SDK" \
   --app ${app_slug} --token ${api_token}
 
@@ -56,12 +57,12 @@ replicated release create --promote Unstable --yaml-dir /home/replicant/release 
 release_sequence=$(curl --header "Accept: application/json" --header "Authorization: ${api_token}" https://api.replicated.com/vendor/v3/apps | jq -r '.apps[0].channels[] | select( .name == "Unstable" ) | .releaseSequence')
 
 # promote to the `Beta` channel
-replicated release promote ${release_sequence} Beta --version 16.7.0 \
+replicated release promote ${release_sequence} Beta --version 19.2.0 \
   --release-notes "Prepares for distribution with Replicated by incorporating the Replicated SDK" \
   --app ${app_slug} --token ${api_token}
  
 # promote to the `Stable` channel
-replicated release promote ${release_sequence} Stable --version 16.7.0 \
+replicated release promote ${release_sequence} Stable --version 19.2.0 \
   --release-notes "Prepares for distribution with Replicated by incorporating the Replicated SDK" \
   --app ${app_slug} --token ${api_token}
 
@@ -70,7 +71,7 @@ replicated channel create --name LTS --description "Releases with long-term supp
   --app ${app_slug} --token ${api_token}
 
 # remove the helm chart we used to create the release
-rm /home/replicant/release/harbor-16.7.0.tgz
+rm /home/replicant/release/harbor-19.2.0.tgz
 
 ## release the application with the Replicated SDK
 # add preflight checks to the Helm chart
@@ -158,14 +159,14 @@ stringData:
 HARBOR_PREFLIGHTS
 
 # bump the version
-yq -i '.version = "16.8.0"' /home/replicant/harbor/Chart.yaml
+yq -i '.version = "19.3.0"' /home/replicant/harbor/Chart.yaml
 helm package /home/replicant/harbor --destination /home/replicant/release
 chown -R replicant /home/replicant/harbor /home/replicant/release
 
 ## release and promote the preflight checks added
 
 # release to the `Unstable` channel
-replicated release create --promote Unstable --yaml-dir /home/replicant/release --version 16.8.0 \
+replicated release create --promote Unstable --yaml-dir /home/replicant/release --version 19.3.0 \
   --release-notes "Adds preflight checks to enable customers to validate cluster prerequisites before installing" \
   --app ${app_slug} --token ${api_token}
 
@@ -173,17 +174,17 @@ replicated release create --promote Unstable --yaml-dir /home/replicant/release 
 release_sequence=$(curl --header "Accept: application/json" --header "Authorization: ${api_token}" https://api.replicated.com/vendor/v3/apps | jq -r '.apps[0].channels[] | select( .name == "Unstable" ) | .releaseSequence')
 
 # promote to the `Beta` channel
-replicated release promote ${release_sequence} Beta --version 16.8.0 \
+replicated release promote ${release_sequence} Beta --version 19.3.0 \
   --release-notes "Adds preflight checks to enable customers to validate cluster prerequisites before installing" \
   --app ${app_slug} --token ${api_token}
  
 # promote to the `Stable` channel
-replicated release promote ${release_sequence} Stable --version 16.8.0 \
+replicated release promote ${release_sequence} Stable --version 19.3.0 \
   --release-notes "Adds preflight checks to enable customers to validate cluster prerequisites before installing" \
   --app ${app_slug} --token ${api_token}
 
 # remove the helm chart we used to create the release
-rm /home/replicant/release/harbor-16.8.0.tgz
+rm /home/replicant/release/harbor-19.3.0.tgz
 
 ## create the customer from the preflights lab
 
@@ -216,7 +217,7 @@ helm registry login registry.replicated.com \
 # install the application, trying again if it fails since there might be timing issues
 set +e
 retries=0
-while ! helm install harbor --version 16.8.0 \
+while ! helm install harbor --version 19.3.0 \
   oci://registry.replicated.com/${app_slug}/harbor \
   --set service.type=NodePort --set service.nodePort.https=30443 \
   --set externalURL=https://cluster-30443-${INSTRUQT_PARTICIPANT_ID}.env.play.instruqt.com \

--- a/instruqt/closing-information-gap/track_scripts/setup-shell
+++ b/instruqt/closing-information-gap/track_scripts/setup-shell
@@ -49,7 +49,7 @@ helm package harbor --destination release
 ## release and promote the app with the SDK added
 
 # release to the `Unstable` channel
-replicated release create --promote Unstable --yaml-dir /home/replicant/release --version 19.2.0 \
+replicated release create --promote Unstable --chart /home/replicant/release/harbor-19.2.0.tgz --version 19.2.0 \
   --release-notes "Prepares for distribution with Replicated by incorporating the Replicated SDK" \
   --app ${app_slug} --token ${api_token}
 
@@ -166,7 +166,7 @@ chown -R replicant /home/replicant/harbor /home/replicant/release
 ## release and promote the preflight checks added
 
 # release to the `Unstable` channel
-replicated release create --promote Unstable --yaml-dir /home/replicant/release --version 19.3.0 \
+replicated release create --promote Unstable --chart /home/replicant/release/harbor-19.3.0.tgz --version 19.3.0 \
   --release-notes "Adds preflight checks to enable customers to validate cluster prerequisites before installing" \
   --app ${app_slug} --token ${api_token}
 
@@ -192,7 +192,7 @@ rm /home/replicant/release/harbor-19.3.0.tgz
 customer_email="${INSTRUQT_PARTICIPANT_ID}@geeglo.io"
 
 # create the new customer and keep track of the ID
-customer_id=$(replicated customer create --name "Geeglo" --email ${customer_email} --channel Stable --expires-in 720h --output json --app ${app_slug} --token ${api_token} | jq -r .id)
+customer_id=$(replicated customer create --name "Geeglo" --email ${customer_email} --channel Stable --expires-in 720h --kots-install=false --output json --app ${app_slug} --token ${api_token} | jq -r .id)
 
 # make sure the customer has a trial license
 updated_customer=$(curl --header 'Accept: application/json' --header "Authorization: ${api_token}" "https://api.replicated.com/vendor/v3/app/${app_id}/customer/${customer_id}" | \

--- a/instruqt/distributing-with-replicated/01-preparing-to-use-the-sdk/assignment.md
+++ b/instruqt/distributing-with-replicated/01-preparing-to-use-the-sdk/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: preparing-to-use-the-sdk
-id: nyq00jogbv0q
+id: nlsiefddbiay
 type: challenge
 title: Preparing to Use the SDK
 teaser: Getting ready to use the Replicated SDK

--- a/instruqt/distributing-with-replicated/01-preparing-to-use-the-sdk/assignment.md
+++ b/instruqt/distributing-with-replicated/01-preparing-to-use-the-sdk/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: preparing-to-use-the-sdk
-id: nlsiefddbiay
+id: mneddevjccio
 type: challenge
 title: Preparing to Use the SDK
 teaser: Getting ready to use the Replicated SDK
@@ -54,7 +54,7 @@ Helm chart. Let's pull down the chart so that we can get
 started.
 
 ```bash
-helm pull --version 16.6.8 oci://registry-1.docker.io/bitnamicharts/harbor --untar
+helm pull --version 19.1.0 oci://registry-1.docker.io/bitnamicharts/harbor --untar
 ```
 
 Let's also set up our shell for interacting with the Replicated

--- a/instruqt/distributing-with-replicated/01-preparing-to-use-the-sdk/check-shell
+++ b/instruqt/distributing-with-replicated/01-preparing-to-use-the-sdk/check-shell
@@ -9,7 +9,7 @@ SESSION=$(tmux save-buffer -)
 
 # check for disconnection
 result=0
-if ! grep -qE 'REPLICATED_API_TOKEN=[A-Za-z "]+' <(echo ${SESSION}) ; then
+if ! grep -qE 'REPLICATED_API_TOKEN=[A-Za-z0-9 "]+' <(echo ${SESSION}) ; then
   fail-message 'Please set the variable `$REPLICATED_API_TOKEN` so you will be able to use the `replicated` command in future steps'
   let "result = result + 1" 
 fi

--- a/instruqt/distributing-with-replicated/01-preparing-to-use-the-sdk/solve-shell
+++ b/instruqt/distributing-with-replicated/01-preparing-to-use-the-sdk/solve-shell
@@ -17,4 +17,4 @@ fi
 
 tmux send-keys -t shell export SPACE 'REPLICATED_API_TOKEN=' "$(agent variable get REPLICATED_API_TOKEN)" ENTER
 tmux send-keys -t shell export SPACE 'REPLICATED_APP=' "$(agent variable get REPLICATED_APP)" ENTER
-tmux send-keys -t shell 'helm pull --version 16.6.8 oci://registry-1.docker.io/bitnamicharts/harbor --untar' ENTER
+tmux send-keys -t shell 'helm pull --version 19.1.0 oci://registry-1.docker.io/bitnamicharts/harbor --untar' ENTER

--- a/instruqt/distributing-with-replicated/02-enabling-the-sdk/assignment.md
+++ b/instruqt/distributing-with-replicated/02-enabling-the-sdk/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: enabling-the-sdk
-id: wy7eklcxxw6c
+id: zulqmrtftnst
 type: challenge
 title: Enabling the Replicated SDK
 teaser: Incorporate the SDK into your application

--- a/instruqt/distributing-with-replicated/02-enabling-the-sdk/assignment.md
+++ b/instruqt/distributing-with-replicated/02-enabling-the-sdk/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: enabling-the-sdk
-id: zulqmrtftnst
+id: pzlc29lz2h9y
 type: challenge
 title: Enabling the Replicated SDK
 teaser: Incorporate the SDK into your application
@@ -63,7 +63,7 @@ a fairly large change. It's not a breaking change, though, so
 let's just bump the minor version number.
 
 ```
-version: 16.7.0
+version: 19.2.0
 ```
 
 ![Bumping the Chart Version](../assets/bumping-the-version.png)
@@ -101,5 +101,5 @@ ls release
 which shows
 
 ```
-harbor-16.7.0.tgz
+harbor-19.2.0.tgz
 ```

--- a/instruqt/distributing-with-replicated/02-enabling-the-sdk/check-shell
+++ b/instruqt/distributing-with-replicated/02-enabling-the-sdk/check-shell
@@ -5,7 +5,7 @@ set -euxo pipefail
 
 result=0
 # check for an updated version number
-if [[ "$(yq .version mastodon/Chart.yaml)" == "16.7.0"  ]] ; then
+if [[ "$(yq .version mastodon/Chart.yaml)" == "19.2.0"  ]] ; then
   fail-message 'Please be sure to update the version of the Mastodon Helm chart to reflect your changes'
   let "result = result + 1"
 fi
@@ -23,7 +23,7 @@ if [[ "$(yq  '.dependencies[] | select ( .name == "replicated" ) | .name')" == "
 fi
 
 # check for the repackaged Helm chart
-if [[ ! -f /home/replicant/release/harbor-16.7.0.tgz ]] ; then
+if [[ ! -f /home/replicant/release/harbor-19.2.0.tgz ]] ; then
   fail-message 'Please be sure to update and repackage the Harbor Helm chart' 
   let "result = result + 1"
 fi

--- a/instruqt/distributing-with-replicated/02-enabling-the-sdk/solve-shell
+++ b/instruqt/distributing-with-replicated/02-enabling-the-sdk/solve-shell
@@ -16,7 +16,7 @@ if ! tmux has-session -t shell ; then
 fi
 
 # updat the chart version
-tmux send-keys -t shell $'yq -i \'.version = "16.7.0"\' harbor/Chart.yaml' ENTER
+tmux send-keys -t shell $'yq -i \'.version = "19.2.0"\' harbor/Chart.yaml' ENTER
 
 # add the SDK dependency
 tmux send-keys -t shell "yq -i '.dependencies += { \"name\": \"replicated\", \"repository\": \"oci://registry.replicated.com/library\", \"version\": \"$(agent variable get REPLICATED_SDK_VERSION)\"}' harbor/Chart.yaml" ENTER

--- a/instruqt/distributing-with-replicated/03-creating-a-release/assignment.md
+++ b/instruqt/distributing-with-replicated/03-creating-a-release/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: creating-a-release
-id: tbxasfcudqc1
+id: xfimjuqgm1r5
 type: challenge
 title: Releasing an Application
 teaser: Creating a release on the Replicated Platform

--- a/instruqt/distributing-with-replicated/03-creating-a-release/assignment.md
+++ b/instruqt/distributing-with-replicated/03-creating-a-release/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: creating-a-release
-id: xfimjuqgm1r5
+id: qwjuyn8lmauy
 type: challenge
 title: Releasing an Application
 teaser: Creating a release on the Replicated Platform
@@ -85,11 +85,11 @@ To create a release, run the following command. We're using the
 `Unstable` channel since we're releasing our most recent change.
 
 ```
-replicated release create --promote Unstable --yaml-dir ./release --version 16.7.0  \
+replicated release create --promote Unstable --yaml-dir ./release --version 19.2.0  \
   --release-notes "Prepares for distribution with Replicated by incorporating the Replicated SDK"
 ```
 
-This creates a release for version `16.7.0` of your Harbor Helm
+This creates a release for version `19.2.0` of your Harbor Helm
 chart, and promotes it to the `Unstable` channel.  The `create`
 command output a sequence number that you'll need for `promote`
 (it will be `1` if you haven't explored releasing a bit more).
@@ -127,14 +127,14 @@ promoting to `Beta`, and ultimately releasing on `Stable`.
 For the purposes of the lab, let's just promote the release straight through.
 
 ```
-replicated release promote 1 Beta --version 16.7.0 \
+replicated release promote 1 Beta --version 19.2.0 \
   --release-notes "Prepares for distribution with Replicated by incorporating the Replicated SDK"
 ```
 
 and then
 
 ```
-replicated release promote 1 Stable --version 16.7.0 \
+replicated release promote 1 Stable --version 19.2.0 \
   --release-notes "Prepares for distribution with Replicated by incorporating the Replicated SDK"
 ```
 

--- a/instruqt/distributing-with-replicated/03-creating-a-release/assignment.md
+++ b/instruqt/distributing-with-replicated/03-creating-a-release/assignment.md
@@ -85,7 +85,7 @@ To create a release, run the following command. We're using the
 `Unstable` channel since we're releasing our most recent change.
 
 ```
-replicated release create --promote Unstable --yaml-dir ./release --version 19.2.0  \
+replicated release create --promote Unstable --chart ./release/harbor-19.2.0.tgz --version 19.2.0  \
   --release-notes "Prepares for distribution with Replicated by incorporating the Replicated SDK"
 ```
 

--- a/instruqt/distributing-with-replicated/03-creating-a-release/check-shell
+++ b/instruqt/distributing-with-replicated/03-creating-a-release/check-shell
@@ -17,22 +17,22 @@ fi
 
 # check for release to Unstable
 unstable_version=$(curl --header "Accept: application/json" --header "Authorization: ${api_token}" https://api.replicated.com/vendor/v3/apps | jq -r '.apps[0].channels[] | select( .name == "Unstable" ) | .currentVersion')
-if [[ ! "${unstable_version}" == "16.7.0"  ]] ; then
-  fail-message $'Please be sure to release the applicaton to the \`Unstable\` channel with version \`16.7.0\`'
+if [[ ! "${unstable_version}" == "19.2.0"  ]] ; then
+  fail-message $'Please be sure to release the applicaton to the \`Unstable\` channel with version \`19.2.0\`'
   let "result = result + 1"
 fi
 
 # check for promotion to Beta
 beta_version=$(curl --header "Accept: application/json" --header "Authorization: ${api_token}" https://api.replicated.com/vendor/v3/apps | jq -r '.apps[0].channels[] | select( .name == "Beta" ) | .currentVersion')
-if [[ ! "${beta_version}" == "16.7.0"  ]] ; then
-  fail-message $'Please be sure to promote the applicaton to the \`Beta\` channel with version \`16.7.0\`'
+if [[ ! "${beta_version}" == "19.2.0"  ]] ; then
+  fail-message $'Please be sure to promote the applicaton to the \`Beta\` channel with version \`19.2.0\`'
   let "result = result + 1"
 fi
 
 # check for promotion to Stable
 stable_version=$(curl --header "Accept: application/json" --header "Authorization: ${api_token}" https://api.replicated.com/vendor/v3/apps | jq -r '.apps[0].channels[] | select( .name == "Stable" ) | .currentVersion')
-if [[ ! "${stable_version}" == "16.7.0"  ]] ; then
-  fail-message $'Please be sure to promote the applicaton to the \`Stable\` channel with version \`16.7.0\`'
+if [[ ! "${stable_version}" == "19.2.0"  ]] ; then
+  fail-message $'Please be sure to promote the applicaton to the \`Stable\` channel with version \`19.2.0\`'
   let "result = result + 1"
 fi
 

--- a/instruqt/distributing-with-replicated/03-creating-a-release/solve-shell
+++ b/instruqt/distributing-with-replicated/03-creating-a-release/solve-shell
@@ -21,7 +21,7 @@ replicated channel create --name LTS --description "Releases with long-term supp
   --app ${app_slug} --token ${api_token}
 
 # release to the `Unstable` channel
-replicated release create --promote Unstable --yaml-dir /home/replicant/release --version 16.7.0 \
+replicated release create --promote Unstable --yaml-dir /home/replicant/release --version 19.2.0 \
   --release-notes "Prepares for distribution with Replicated by incorporating the Replicated SDK" \
   --app ${app_slug} --token ${api_token}
 
@@ -29,11 +29,11 @@ replicated release create --promote Unstable --yaml-dir /home/replicant/release 
 release_sequence=$(curl --header "Accept: application/json" --header "Authorization: ${api_token}" https://api.replicated.com/vendor/v3/apps | jq -r '.apps[0].channels[] | select( .name == "Unstable" ) | .releaseSequence')
 
 # promote to the `Beta` channel
-replicated release promote ${release_sequence} Beta --version 16.7.0 \
+replicated release promote ${release_sequence} Beta --version 19.2.0 \
   --release-notes "Prepares for distribution with Replicated by incorporating the Replicated SDK" \
   --app ${app_slug} --token ${api_token}
  
 # promote to the `Stable` channel
-replicated release promote ${release_sequence} Stable --version 16.7.0 \
+replicated release promote ${release_sequence} Stable --version 19.2.0 \
   --release-notes "Prepares for distribution with Replicated by incorporating the Replicated SDK" \
   --app ${app_slug} --token ${api_token}

--- a/instruqt/distributing-with-replicated/03-creating-a-release/solve-shell
+++ b/instruqt/distributing-with-replicated/03-creating-a-release/solve-shell
@@ -21,7 +21,7 @@ replicated channel create --name LTS --description "Releases with long-term supp
   --app ${app_slug} --token ${api_token}
 
 # release to the `Unstable` channel
-replicated release create --promote Unstable --yaml-dir /home/replicant/release --version 19.2.0 \
+replicated release create --promote Unstable --chart ./release/harbor-19.2.0/tgz --version 19.2.0  \
   --release-notes "Prepares for distribution with Replicated by incorporating the Replicated SDK" \
   --app ${app_slug} --token ${api_token}
 

--- a/instruqt/distributing-with-replicated/04-installing-the-application/assignment.md
+++ b/instruqt/distributing-with-replicated/04-installing-the-application/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: installing-the-application
-id: cqhjo8z5iier
+id: 0jr3scssmdfw
 type: challenge
 title: Installing the Application
 teaser: Let's install the application as your customer
@@ -42,7 +42,7 @@ Password: `[[ Instruqt-Var key="PASSWORD" hostname="shell" ]]`
 
 You'll land on the "Channels" page for your app, which will show
 the release channels we discussed in the previous step. Notice that
-each channel shows the current version `16.7.0` while the channel LTS, which we haven't released to, reflects
+each channel shows the current version `19.2.0` while the channel LTS, which we haven't released to, reflects
 that.
 
 ![Vendor Portal Release Channels](../assets/vendor-portal-landing.png)

--- a/instruqt/distributing-with-replicated/04-installing-the-application/assignment.md
+++ b/instruqt/distributing-with-replicated/04-installing-the-application/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: installing-the-application
-id: le06dzuzl81y
+id: cqhjo8z5iier
 type: challenge
 title: Installing the Application
 teaser: Let's install the application as your customer

--- a/instruqt/distributing-with-replicated/04-installing-the-application/check-shell
+++ b/instruqt/distributing-with-replicated/04-installing-the-application/check-shell
@@ -8,7 +8,7 @@ result=0
 
 # check for release to Unstable
 installed_chart=$(helm list -o yaml --kubeconfig /home/replicant/.kube/config | yq '.[0].chart')
-if [[ ! "${installed_chart}" == "harbor-16.7.0"  ]] ; then
+if [[ ! "${installed_chart}" == "harbor-19.2.0"  ]] ; then
   fail-message 'Please be sure to install the Harbor Helm chart'
   let "result = result + 1"
 fi

--- a/instruqt/distributing-with-replicated/05-validating-the-install/assignment.md
+++ b/instruqt/distributing-with-replicated/05-validating-the-install/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: validating-the-install
-id: wsuxuhp33vfz
+id: vtvk2dkrwklo
 type: challenge
 title: Observing the Customer Instance
 teaser: Observing your customer install

--- a/instruqt/distributing-with-replicated/05-validating-the-install/assignment.md
+++ b/instruqt/distributing-with-replicated/05-validating-the-install/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: validating-the-install
-id: dwuqvl8c7wrr
+id: wsuxuhp33vfz
 type: challenge
 title: Observing the Customer Instance
 teaser: Observing your customer install

--- a/instruqt/distributing-with-replicated/config.yml
+++ b/instruqt/distributing-with-replicated/config.yml
@@ -1,7 +1,7 @@
 version: "3"
 containers:
 - name: shell
-  image: gcr.io/kots-field-labs/shell:instruqt-feature-tmux-template
+  image: gcr.io/kots-field-labs/shell:main
   shell: tmux new-session -A -s shell su - replicant
 virtualmachines:
 - name: cluster

--- a/instruqt/distributing-with-replicated/track.yml
+++ b/instruqt/distributing-with-replicated/track.yml
@@ -26,4 +26,4 @@ lab_config:
   width: 33
   position: right
   enableLoadingMessages: true
-checksum: "9421035943818506418"
+checksum: "8962139012837110268"

--- a/instruqt/distributing-with-replicated/track.yml
+++ b/instruqt/distributing-with-replicated/track.yml
@@ -25,4 +25,5 @@ lab_config:
   overlay: false
   width: 33
   position: right
-checksum: "4697812039007069627"
+  enableLoadingMessages: true
+checksum: "9421035943818506418"

--- a/instruqt/distributing-with-replicated/track.yml
+++ b/instruqt/distributing-with-replicated/track.yml
@@ -1,5 +1,5 @@
 slug: distributing-with-replicated
-id: 
+id: evmpzv6ycpgs
 title: Distributing Your Application with Replicated
 description: |-
   Learn how to quickly take advantage of the Replicated Platform for
@@ -14,16 +14,15 @@ description: |-
 icon: https://storage.googleapis.com/shared-lab-assets/icons/red/appslug.png
 level: beginner
 tags:
-- builders-plan
-- sdk
-- helm
 - prod
+- builders-plan
+- helm
+- sdk
 owner: replicated
 developers:
 - chuck@replicated.com
-maintenance: false
 lab_config:
   overlay: false
   width: 33
   position: right
-checksum: "11868235989270449838"
+checksum: "4697812039007069627"

--- a/instruqt/distributing-with-replicated/track.yml
+++ b/instruqt/distributing-with-replicated/track.yml
@@ -26,4 +26,4 @@ lab_config:
   width: 33
   position: right
   enableLoadingMessages: true
-checksum: "8962139012837110268"
+checksum: "18108961214425884926"

--- a/instruqt/distributing-with-replicated/track.yml
+++ b/instruqt/distributing-with-replicated/track.yml
@@ -26,4 +26,4 @@ lab_config:
   width: 33
   position: right
   enableLoadingMessages: true
-checksum: "18108961214425884926"
+checksum: "10082946159492732371"

--- a/setup/pkg/fieldlabs/environment_create.go
+++ b/setup/pkg/fieldlabs/environment_create.go
@@ -119,81 +119,85 @@ func (e *EnvironmentManager) createVendorTrack(app types.App, trackSpec TrackSpe
 	appTrackSlug := fmt.Sprintf("%s-%s", app.Slug, track.Spec.Slug)
 	e.Log.ActionWithSpinner("Provision track %s", appTrackSlug)
 
+  // get the stable channel to assign for customer
+  channel, err := e.getChannel(track)
+  if err != nil {
+    return errors.Wrapf(err, "get Stable channel")
+  }
+  track.Status.Channel = channel
+
+  // Create customer
+  if trackSpec.Customer != "" {
+    customer, err := e.getOrCreateCustomer(track)
+    if err != nil {
+      return errors.Wrapf(err, "create customer for track %q app %q", trackSpec.Slug, app.Slug)
+    }
+    track.Status.Customer = customer
+  }
+
 	// load yaml for releases first to ensure directories exist
-	kotsYAML, err := readYAMLDir(fmt.Sprintf("%s/%s", e.VendorLoc, trackSpec.YAMLDir))
-	if err != nil {
-		return errors.Wrapf(err, "read yaml dir %q", fmt.Sprintf("%s/%s", e.VendorLoc, trackSpec.YAMLDir))
-	}
+  if trackSpec.YAMLDir != "" { 
+    kotsYAML, err := readYAMLDir(fmt.Sprintf("%s/%s", e.VendorLoc, trackSpec.YAMLDir))
 
-	for _, extraRelease := range track.Spec.ExtraReleases {
-		kotsYAML, err := readYAMLDir(fmt.Sprintf("%s/%s", e.VendorLoc, extraRelease.YAMLDir))
-		if err != nil {
-			return errors.Wrapf(err, "read yaml dir %q", fmt.Sprintf("%s/%s", e.VendorLoc, trackSpec.YAMLDir))
-		}
-		track.Status.ExtraReleases = append(track.Status.ExtraReleases, ExtraReleaseStatus{
-			Spec: extraRelease,
-			YAML: kotsYAML,
-		})
+    if err != nil {
+      return errors.Wrapf(err, "read yaml dir %q", fmt.Sprintf("%s/%s", e.VendorLoc, trackSpec.YAMLDir))
+    }
 
-	}
+    for _, extraRelease := range track.Spec.ExtraReleases {
+      kotsYAML, err := readYAMLDir(fmt.Sprintf("%s/%s", e.VendorLoc, extraRelease.YAMLDir))
+      if err != nil {
+        return errors.Wrapf(err, "read yaml dir %q", fmt.Sprintf("%s/%s", e.VendorLoc, trackSpec.YAMLDir))
+      }
+      track.Status.ExtraReleases = append(track.Status.ExtraReleases, ExtraReleaseStatus{
+        Spec: extraRelease,
+        YAML: kotsYAML,
+      })
 
-	channel, err := e.getChannel(track)
-	if err != nil {
-		return errors.Wrapf(err, "get Stable channel")
-	}
-	track.Status.Channel = channel
+    }
 
-	if trackSpec.Customer != "" {
-		customer, err := e.getOrCreateCustomer(track)
-		if err != nil {
-			return errors.Wrapf(err, "create customer for track %q app %q", trackSpec.Slug, app.Slug)
-		}
-		track.Status.Customer = customer
-	}
+    release, err := e.Client.CreateRelease(app.ID, kotsYAML)
+    if err != nil {
+      return errors.Wrapf(err, "create release for %q", fmt.Sprintf("%s/%s", e.VendorLoc, trackSpec.YAMLDir))
+    }
 
-	release, err := e.Client.CreateRelease(app.ID, kotsYAML)
-	if err != nil {
-		return errors.Wrapf(err, "create release for %q", fmt.Sprintf("%s/%s", e.VendorLoc, trackSpec.YAMLDir))
-	}
+    track.Status.Release = release
 
-	track.Status.Release = release
+    err = e.Client.PromoteRelease(app.ID, release.Sequence, "0.1.0", trackSpec.Slug, false, channel.ID)
+    if err != nil {
+      return errors.Wrapf(err, "promote release %d to channel %q", release.Sequence, channel.Slug)
+    }
 
-	err = e.Client.PromoteRelease(app.ID, release.Sequence, "0.1.0", trackSpec.Slug, false, channel.ID)
-	if err != nil {
-		return errors.Wrapf(err, "promote release %d to channel %q", release.Sequence, channel.Slug)
-	}
+    for _, extraRelease := range track.Status.ExtraReleases {
+      releaseInfo, err := e.Client.CreateRelease(app.ID, extraRelease.YAML)
+      if err != nil {
+        return errors.Wrapf(err, "create release for %q", fmt.Sprintf("%s/%s", e.VendorLoc, extraRelease.Spec.YAMLDir))
+      }
+      extraRelease.Release = releaseInfo
 
-	for _, extraRelease := range track.Status.ExtraReleases {
-		releaseInfo, err := e.Client.CreateRelease(app.ID, extraRelease.YAML)
-		if err != nil {
-			return errors.Wrapf(err, "create release for %q", fmt.Sprintf("%s/%s", e.VendorLoc, extraRelease.Spec.YAMLDir))
-		}
-		extraRelease.Release = releaseInfo
+      if extraRelease.Spec.PromoteChannel != "" {
 
-		if extraRelease.Spec.PromoteChannel != "" {
+        continue
+      }
+    }
 
-			continue
-		}
-	}
+    if trackSpec.K8sInstallerYAMLPath != "" {
+      kurlYAML, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", e.VendorLoc, trackSpec.K8sInstallerYAMLPath))
+      if err != nil {
+        return errors.Wrapf(err, "read installer yaml %q", fmt.Sprintf("%s/%s", e.VendorLoc, trackSpec.K8sInstallerYAMLPath))
+      }
 
-	if trackSpec.K8sInstallerYAMLPath != "" {
-		kurlYAML, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", e.VendorLoc, trackSpec.K8sInstallerYAMLPath))
-		if err != nil {
-			return errors.Wrapf(err, "read installer yaml %q", fmt.Sprintf("%s/%s", e.VendorLoc, trackSpec.K8sInstallerYAMLPath))
-		}
+      installer, err := e.Client.CreateInstaller(app.ID, string(kurlYAML))
+      if err != nil {
+        return errors.Wrapf(err, "create installer from %q", fmt.Sprintf("%s/%s", e.VendorLoc, trackSpec.K8sInstallerYAMLPath))
+      }
+      track.Status.Installer = installer
 
-		installer, err := e.Client.CreateInstaller(app.ID, string(kurlYAML))
-		if err != nil {
-			return errors.Wrapf(err, "create installer from %q", fmt.Sprintf("%s/%s", e.VendorLoc, trackSpec.K8sInstallerYAMLPath))
-		}
-		track.Status.Installer = installer
-
-		err = e.Client.PromoteInstaller(app.ID, installer.Sequence, channel.ID, trackSpec.Slug)
-		if err != nil {
-			return errors.Wrapf(err, "promote installer %d to channel %q", installer.Sequence, channel.Slug)
-		}
-	}
-
+      err = e.Client.PromoteInstaller(app.ID, installer.Sequence, channel.ID, trackSpec.Slug)
+      if err != nil {
+        return errors.Wrapf(err, "promote installer %d to channel %q", installer.Sequence, channel.Slug)
+      }
+    }
+  }
 	return nil
 }
 


### PR DESCRIPTION
TL;DR
-----

Repairs several defects surfaced while reviewing labs before Kubecon

Details
-------

* Fixes lab setup to create a customer even when thee `vendor.json` file doesn't specify any files for the release.
* Uses a newer version of the Harbor chart for the "builder" labs to both sync back up and address some issues with Helm installs
* Creates release from chart tarball rather than from the YAML dir
* Assures created customers aren't KOTS enabled
* Corrects some lifecycle scripts that were leading to inconsistent lab instructions and some failures that weren't failures
* Clears a couple of typos


