### PR TITLE
Update environment_create.go

### DIFF
--- a/setup/pkg/fieldlabs/environment_create.go
+++ b/setup/pkg/fieldlabs/environment_create.go
@@ -242,7 +242,7 @@ func (e *EnvironmentManager) getOrCreateCustomer(track Track) (*types.Customer, 
 		}
 	}
 
-  var createOpts = kotsclient.CreateCustomerOpts{ Name: track.Spec.Customer, AppID: track.Status.App.ID, Email: track.Spec.Customer + "@replicated-labs.com", ChannelID: track.Status.Channel.ID, ExpiresAt: OneWeek }
+  var createOpts = kotsclient.CreateCustomerOpts{ Name: track.Spec.Customer, AppID: track.Status.App.ID, Email: track.Spec.Customer + "@replicatedlabs.com", ChannelID: track.Status.Channel.ID, ExpiresAt: OneWeek }
 	customer, err := e.Client.CreateCustomer(createOpts) 
 	if err != nil {
 		return nil, errors.Wrapf(err, "create customer for track %q app %q", track.Spec.Slug, track.Status.App.Slug)


### PR DESCRIPTION
The error message is: POST https://api.replicated.com/vendor/v3/customer 400: failed to validate email address: mail: no angle-addr"
Changing the email address to not contain `-` should fix the creation of customers