### PR TITLE
Limits testing to active labs

### DIFF
--- a/.github/workflows/instruqt-generate-track-slugs.yml
+++ b/.github/workflows/instruqt-generate-track-slugs.yml
@@ -39,7 +39,7 @@ jobs:
         uses: mikefarah/yq@master
         with:
           cmd: |
-            yq eval-all 'select(.id != null and .slug != null) | . as $item ireduce ([]; . + [{"slug": $item.slug, "id": $item.id}]) | {"tracks": . }' ${{ steps.find-track-descriptors.outputs.files }}
+            yq eval-all 'select(.id != null and .slug != null and ( contains({ "tags": "deprecated"}) | not ) and (  contains({ "tags": "template" } ) | not) and ( contains( { "tags": "internal" } ) | not ) ) | . as $item ireduce ([]; . + [{"slug": $item.slug, "id": $item.id}]) | {"tracks": . }'
 
       - name: Update track slugs metadata
         id: update-slugs

--- a/instruqt/sample/track.yml
+++ b/instruqt/sample/track.yml
@@ -7,7 +7,8 @@ description: |-
 
   You can use any GitHub flavoured markdown.
 icon: https://storage.googleapis.com/instruqt-frontend/img/tracks/default.png
-tags: []
+tags:
+- deprecated
 owner: replicated
 developers:
 - joshd@replicated.com

--- a/instruqt/shared-env-template/track.yml
+++ b/instruqt/shared-env-template/track.yml
@@ -23,7 +23,8 @@ description: |-
   pane content and running a grep against it, see the sample
   check script in the first challenge for an example.
 icon: https://storage.googleapis.com/instruqt-frontend/img/tracks/default.png
-tags: []
+tags:
+- template
 owner: replicated
 developers:
 - chuck@replicated.com

--- a/instruqt/short-demo/track.yml
+++ b/instruqt/short-demo/track.yml
@@ -15,7 +15,8 @@ description: |-
   It contains a container with the replicated CLI pre-installed.
   It contains an editor with the manifests pre-loaded as an IDE example
 icon: https://storage.googleapis.com/instruqt-frontend/img/tracks/default.png
-tags: []
+tags: 
+- internal
 owner: replicated
 developers:
 - joshd@replicated.com

--- a/instruqt/track-slugs.yml
+++ b/instruqt/track-slugs.yml
@@ -1,8 +1,4 @@
 tracks:
-  - slug: airgap-template
-    id: 8p7434ifnsyd
-  - slug: proxy
-    id: 8txqwacwfxcu
   - slug: replicated-cli
     id: pur3nyzcbryg
   - slug: hello-world
@@ -11,20 +7,8 @@ tracks:
     id: hfb41xqkyx0q
   - slug: custom-fields
     id: 9ixa2iyrggut
-  - slug: technical-peer-review
-    id: nrjmvv9bmgky
-  - slug: shell-and-cluster-template
-    id: r0qomiqpceeg
-  - slug: shared-env-template
-    id: xnjer5tunrrn
-  - slug: short-demo
-    id: iecexaqfyu6j
   - slug: redactors
     id: gmiwrds3jmuy
-  - slug: validating-compatibility
-    id: riga8tcknxdy
-  - slug: sample
-    id: tvc3c4ohghbi
   - slug: distributing-with-replicated
     id: evmpzv6ycpgs
   - slug: airgap-embedded


### PR DESCRIPTION
TL;DR
-----

Avoid running test on labs that don't need it

Details
-------

Scales back our twice a day testing to not test tracks that aren't
usd independently by customers like templates, demos, and inteview
tools.
