### PR TITLE
Modernizes shell image build

### DIFF
--- a/.github/workflows/build-shell-image.yaml
+++ b/.github/workflows/build-shell-image.yaml
@@ -29,13 +29,13 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Authenicate to Google Cloud
-      uses: google-github-actions/auth@v0
+      uses: google-github-actions/auth@v2
       with:
         credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
 
     - name: Setup Google Cloud SDK
       id: auth
-      uses: google-github-actions/setup-gcloud@v0
+      uses: google-github-actions/setup-gcloud@v2
       with:
         project_id: kots-field-labs
 

--- a/docker/shell/Dockerfile
+++ b/docker/shell/Dockerfile
@@ -30,8 +30,12 @@ RUN curl -s https://api.github.com/repos/replicatedhq/sbctl/releases/latest | \
 FROM installer AS kubectl
 
 # kubectl
-RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
-  echo "deb [arch=amd64] https://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list
+# If the folder `/etc/apt/keyrings` does not exist, it should be created before the curl command, read the note below.
+RUN curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.30/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg && \
+  chmod 644 /etc/apt/keyrings/kubernetes-apt-keyring.gpg 
+
+RUN echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /' | \
+  tee /etc/apt/sources.list.d/kubernetes.list && chmod 644 /etc/apt/sources.list.d/kubernetes.list
 RUN apt-get update && apt-get install -y kubectl 
 
 # final image


### PR DESCRIPTION
TL;DR
-----

Shell image builds were failing and this fixes it

Details
-------

Updates the workflow to build shell images to use newer Google actions and updates the image Dockerfile to get the `kubectl` command from the `k8s.io` repos. The latter is what fixes the broken build, well the former just gets rid of warnings and assures we're using stuff that's still maintained.