### PR TITLE
Refines the shared environment template

### DIFF
--- a/instruqt/shared-env-template/01-getting-to-know-the-template/check-cluster
+++ b/instruqt/shared-env-template/01-getting-to-know-the-template/check-cluster
@@ -2,11 +2,7 @@
 
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
-HOME_DIR=/home/replicant
 source /etc/profile/header.sh
-
-# clear the tmux pane and scrollback to look like a fresh shell
-tmux clear-history -t shell 
-tmux send-keys -t shell clear ENTER
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 
 exit 0

--- a/instruqt/shared-env-template/01-getting-to-know-the-template/check-cluster
+++ b/instruqt/shared-env-template/01-getting-to-know-the-template/check-cluster
@@ -2,7 +2,7 @@
 
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
-source /etc/profile/header.sh
+source /etc/profile.d/header.sh
 export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 
 exit 0

--- a/instruqt/shared-env-template/01-getting-to-know-the-template/check-shell
+++ b/instruqt/shared-env-template/01-getting-to-know-the-template/check-shell
@@ -2,6 +2,8 @@
 
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
+HOME_DIR=/home/replicant
+source /etc/profile/header.sh
 
 # save the entire session to check user inputs and outputs
 tmux capture-pane -t shell -S -

--- a/instruqt/shared-env-template/01-getting-to-know-the-template/check-shell
+++ b/instruqt/shared-env-template/01-getting-to-know-the-template/check-shell
@@ -3,7 +3,7 @@
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
 HOME_DIR=/home/replicant
-source /etc/profile/header.sh
+source /etc/profile.d/header.sh
 
 # save the entire session to check user inputs and outputs
 tmux capture-pane -t shell -S -

--- a/instruqt/shared-env-template/01-getting-to-know-the-template/cleanup-cluster
+++ b/instruqt/shared-env-template/01-getting-to-know-the-template/cleanup-cluster
@@ -2,11 +2,7 @@
 
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
-HOME_DIR=/home/replicant
 source /etc/profile/header.sh
-
-# clear the tmux pane and scrollback to look like a fresh shell
-tmux clear-history -t shell 
-tmux send-keys -t shell clear ENTER
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 
 exit 0

--- a/instruqt/shared-env-template/01-getting-to-know-the-template/cleanup-cluster
+++ b/instruqt/shared-env-template/01-getting-to-know-the-template/cleanup-cluster
@@ -2,7 +2,7 @@
 
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
-source /etc/profile/header.sh
+source /etc/profile.d/header.sh
 export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 
 exit 0

--- a/instruqt/shared-env-template/01-getting-to-know-the-template/cleanup-shell
+++ b/instruqt/shared-env-template/01-getting-to-know-the-template/cleanup-shell
@@ -3,7 +3,7 @@
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
 HOME_DIR=/home/replicant
-source /etc/profile/header.sh
+source /etc/profile.d/header.sh
 
 # clear the tmux pane and scrollback to look like a fresh shell
 tmux clear-history -t shell 

--- a/instruqt/shared-env-template/01-getting-to-know-the-template/setup-cluster
+++ b/instruqt/shared-env-template/01-getting-to-know-the-template/setup-cluster
@@ -2,11 +2,7 @@
 
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
-HOME_DIR=/home/replicant
 source /etc/profile/header.sh
-
-# clear the tmux pane and scrollback to look like a fresh shell
-tmux clear-history -t shell 
-tmux send-keys -t shell clear ENTER
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 
 exit 0

--- a/instruqt/shared-env-template/01-getting-to-know-the-template/setup-cluster
+++ b/instruqt/shared-env-template/01-getting-to-know-the-template/setup-cluster
@@ -2,7 +2,7 @@
 
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
-source /etc/profile/header.sh
+source /etc/profile.d/header.sh
 export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 
 exit 0

--- a/instruqt/shared-env-template/01-getting-to-know-the-template/solve-cluster
+++ b/instruqt/shared-env-template/01-getting-to-know-the-template/solve-cluster
@@ -2,11 +2,7 @@
 
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
-HOME_DIR=/home/replicant
 source /etc/profile/header.sh
-
-# clear the tmux pane and scrollback to look like a fresh shell
-tmux clear-history -t shell 
-tmux send-keys -t shell clear ENTER
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 
 exit 0

--- a/instruqt/shared-env-template/01-getting-to-know-the-template/solve-cluster
+++ b/instruqt/shared-env-template/01-getting-to-know-the-template/solve-cluster
@@ -2,7 +2,7 @@
 
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
-source /etc/profile/header.sh
+source /etc/profile.d/header.sh
 export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 
 exit 0

--- a/instruqt/shared-env-template/01-getting-to-know-the-template/solve-shell
+++ b/instruqt/shared-env-template/01-getting-to-know-the-template/solve-shell
@@ -2,17 +2,8 @@
 
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
+HOME_DIR=/home/replicant
+source /etc/profile/header.sh
 
-### Assure the tmux session exists
-#
-# In a test scenario Instuqt does not run the user shell for the
-# challenge, which means the tmux session is never established. We
-# need to session for the solve scripts for other challenges to 
-# succeed, so let's create it here.
-#
-
-if ! tmux has-session -t shell ; then
-  tmux new-session -d -s shell su - replicant
-fi
-
+# set the variable into the shell
 tmux send-keys -t shell export SPACE 'THIS="the way"' ENTER

--- a/instruqt/shared-env-template/01-getting-to-know-the-template/solve-shell
+++ b/instruqt/shared-env-template/01-getting-to-know-the-template/solve-shell
@@ -3,7 +3,7 @@
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
 HOME_DIR=/home/replicant
-source /etc/profile/header.sh
+source /etc/profile.d/header.sh
 
 # set the variable into the shell
 tmux send-keys -t shell export SPACE 'THIS="the way"' ENTER

--- a/instruqt/shared-env-template/02-using-the-template/check-cluster
+++ b/instruqt/shared-env-template/02-using-the-template/check-cluster
@@ -2,11 +2,7 @@
 
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
-HOME_DIR=/home/replicant
 source /etc/profile/header.sh
-
-# clear the tmux pane and scrollback to look like a fresh shell
-tmux clear-history -t shell 
-tmux send-keys -t shell clear ENTER
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 
 exit 0

--- a/instruqt/shared-env-template/02-using-the-template/check-cluster
+++ b/instruqt/shared-env-template/02-using-the-template/check-cluster
@@ -2,7 +2,7 @@
 
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
-source /etc/profile/header.sh
+source /etc/profile.d/header.sh
 export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 
 exit 0

--- a/instruqt/shared-env-template/02-using-the-template/check-shell
+++ b/instruqt/shared-env-template/02-using-the-template/check-shell
@@ -2,12 +2,14 @@
 
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
+HOME_DIR=/home/replicant
+source /etc/profile/header.sh
 
 # save the entire session to check user inputs and outputs
 tmux capture-pane -t shell -S -
 SESSION=$(tmux save-buffer -)
 
-# check for disconnection
+# check that the variable has been set
 if ! grep -qE 'echo' <(echo ${SESSION}) ; then
   fail-message 'Please make sure you can still access `$THIS`'
   exit 1

--- a/instruqt/shared-env-template/02-using-the-template/check-shell
+++ b/instruqt/shared-env-template/02-using-the-template/check-shell
@@ -3,7 +3,7 @@
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
 HOME_DIR=/home/replicant
-source /etc/profile/header.sh
+source /etc/profile.d/header.sh
 
 # save the entire session to check user inputs and outputs
 tmux capture-pane -t shell -S -

--- a/instruqt/shared-env-template/02-using-the-template/cleanup-cluster
+++ b/instruqt/shared-env-template/02-using-the-template/cleanup-cluster
@@ -2,11 +2,7 @@
 
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
-HOME_DIR=/home/replicant
 source /etc/profile/header.sh
-
-# clear the tmux pane and scrollback to look like a fresh shell
-tmux clear-history -t shell 
-tmux send-keys -t shell clear ENTER
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 
 exit 0

--- a/instruqt/shared-env-template/02-using-the-template/cleanup-cluster
+++ b/instruqt/shared-env-template/02-using-the-template/cleanup-cluster
@@ -2,7 +2,7 @@
 
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
-source /etc/profile/header.sh
+source /etc/profile.d/header.sh
 export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 
 exit 0

--- a/instruqt/shared-env-template/02-using-the-template/setup-cluster
+++ b/instruqt/shared-env-template/02-using-the-template/setup-cluster
@@ -2,11 +2,7 @@
 
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
-HOME_DIR=/home/replicant
 source /etc/profile/header.sh
-
-# clear the tmux pane and scrollback to look like a fresh shell
-tmux clear-history -t shell 
-tmux send-keys -t shell clear ENTER
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 
 exit 0

--- a/instruqt/shared-env-template/02-using-the-template/setup-cluster
+++ b/instruqt/shared-env-template/02-using-the-template/setup-cluster
@@ -2,7 +2,7 @@
 
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
-source /etc/profile/header.sh
+source /etc/profile.d/header.sh
 export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 
 exit 0

--- a/instruqt/shared-env-template/02-using-the-template/setup-shell
+++ b/instruqt/shared-env-template/02-using-the-template/setup-shell
@@ -3,7 +3,7 @@
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
 HOME_DIR=/home/replicant
-source /etc/profile.d/header.sh
+source /etc/profile/header.sh
 
 ### Assure the tmux session exists
 #
@@ -16,9 +16,4 @@ if ! tmux has-session -t shell ; then
   tmux new-session -d -s shell su - replicant
 fi
 
-# Wait for Instruqt bootstrap to be complete
-while [ ! -f /opt/instruqt/bootstrap/host-bootstrap-completed ]
-do
-  echo "Waiting for Instruqt to finish booting the VM"
-  sleep 1
-done
+exit 0

--- a/instruqt/shared-env-template/02-using-the-template/setup-shell
+++ b/instruqt/shared-env-template/02-using-the-template/setup-shell
@@ -3,7 +3,7 @@
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
 HOME_DIR=/home/replicant
-source /etc/profile/header.sh
+source /etc/profile.d/header.sh
 
 ### Assure the tmux session exists
 #

--- a/instruqt/shared-env-template/02-using-the-template/solve-cluster
+++ b/instruqt/shared-env-template/02-using-the-template/solve-cluster
@@ -2,11 +2,7 @@
 
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
-HOME_DIR=/home/replicant
 source /etc/profile/header.sh
-
-# clear the tmux pane and scrollback to look like a fresh shell
-tmux clear-history -t shell 
-tmux send-keys -t shell clear ENTER
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 
 exit 0

--- a/instruqt/shared-env-template/02-using-the-template/solve-cluster
+++ b/instruqt/shared-env-template/02-using-the-template/solve-cluster
@@ -2,7 +2,7 @@
 
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
-source /etc/profile/header.sh
+source /etc/profile.d/header.sh
 export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 
 exit 0

--- a/instruqt/shared-env-template/02-using-the-template/solve-shell
+++ b/instruqt/shared-env-template/02-using-the-template/solve-shell
@@ -2,17 +2,8 @@
 
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
+HOME_DIR=/home/replicant
+source /etc/profile/header.sh
 
-### Assure the tmux session exists
-#
-# In a test scenario Instuqt does not run the user shell for the
-# challenge, which means the tmux session is never established. We
-# need to session for the solve scripts for other challenges to 
-# succeed, so let's create it here.
-#
-
-if ! tmux has-session -t shell ; then
-  tmux new-session -d -s shell su - replicant
-fi
-
+# show the variable in the shell
 tmux send-keys -t shell echo SPACE '$THIS' ENTER

--- a/instruqt/shared-env-template/02-using-the-template/solve-shell
+++ b/instruqt/shared-env-template/02-using-the-template/solve-shell
@@ -3,7 +3,7 @@
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
 HOME_DIR=/home/replicant
-source /etc/profile/header.sh
+source /etc/profile.d/header.sh
 
 # show the variable in the shell
 tmux send-keys -t shell echo SPACE '$THIS' ENTER

--- a/instruqt/shared-env-template/03-tips-and-tricks/check-cluster
+++ b/instruqt/shared-env-template/03-tips-and-tricks/check-cluster
@@ -2,11 +2,7 @@
 
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
-HOME_DIR=/home/replicant
 source /etc/profile/header.sh
-
-# clear the tmux pane and scrollback to look like a fresh shell
-tmux clear-history -t shell 
-tmux send-keys -t shell clear ENTER
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 
 exit 0

--- a/instruqt/shared-env-template/03-tips-and-tricks/check-cluster
+++ b/instruqt/shared-env-template/03-tips-and-tricks/check-cluster
@@ -2,7 +2,7 @@
 
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
-source /etc/profile/header.sh
+source /etc/profile.d/header.sh
 export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 
 exit 0

--- a/instruqt/shared-env-template/03-tips-and-tricks/check-shell
+++ b/instruqt/shared-env-template/03-tips-and-tricks/check-shell
@@ -3,6 +3,6 @@
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
 HOME_DIR=/home/replicant
-source /etc/profile/header.sh
+source /etc/profile.d/header.sh
 
 exit 0

--- a/instruqt/shared-env-template/03-tips-and-tricks/check-shell
+++ b/instruqt/shared-env-template/03-tips-and-tricks/check-shell
@@ -3,9 +3,6 @@
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
 HOME_DIR=/home/replicant
-#
-# clear the tmux pane and scrollback to look like a fresh shell
-tmux clear-history -t shell 
-tmux send-keys -t shell clear ENTER
+source /etc/profile/header.sh
 
 exit 0

--- a/instruqt/shared-env-template/03-tips-and-tricks/cleanup-cluster
+++ b/instruqt/shared-env-template/03-tips-and-tricks/cleanup-cluster
@@ -2,11 +2,7 @@
 
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
-HOME_DIR=/home/replicant
 source /etc/profile/header.sh
-
-# clear the tmux pane and scrollback to look like a fresh shell
-tmux clear-history -t shell 
-tmux send-keys -t shell clear ENTER
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 
 exit 0

--- a/instruqt/shared-env-template/03-tips-and-tricks/cleanup-cluster
+++ b/instruqt/shared-env-template/03-tips-and-tricks/cleanup-cluster
@@ -2,7 +2,7 @@
 
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
-source /etc/profile/header.sh
+source /etc/profile.d/header.sh
 export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 
 exit 0

--- a/instruqt/shared-env-template/03-tips-and-tricks/cleanup-shell
+++ b/instruqt/shared-env-template/03-tips-and-tricks/cleanup-shell
@@ -3,9 +3,7 @@
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
 HOME_DIR=/home/replicant
-#
-# clear the tmux pane and scrollback to look like a fresh shell
-tmux clear-history -t shell 
-tmux send-keys -t shell clear ENTER
+source /etc/profile/header.sh
 
 exit 0
+

--- a/instruqt/shared-env-template/03-tips-and-tricks/cleanup-shell
+++ b/instruqt/shared-env-template/03-tips-and-tricks/cleanup-shell
@@ -3,7 +3,7 @@
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
 HOME_DIR=/home/replicant
-source /etc/profile/header.sh
+source /etc/profile.d/header.sh
 
 exit 0
 

--- a/instruqt/shared-env-template/03-tips-and-tricks/setup-cluster
+++ b/instruqt/shared-env-template/03-tips-and-tricks/setup-cluster
@@ -2,11 +2,7 @@
 
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
-HOME_DIR=/home/replicant
 source /etc/profile/header.sh
-
-# clear the tmux pane and scrollback to look like a fresh shell
-tmux clear-history -t shell 
-tmux send-keys -t shell clear ENTER
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 
 exit 0

--- a/instruqt/shared-env-template/03-tips-and-tricks/setup-cluster
+++ b/instruqt/shared-env-template/03-tips-and-tricks/setup-cluster
@@ -2,7 +2,7 @@
 
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
-source /etc/profile/header.sh
+source /etc/profile.d/header.sh
 export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 
 exit 0

--- a/instruqt/shared-env-template/03-tips-and-tricks/setup-shell
+++ b/instruqt/shared-env-template/03-tips-and-tricks/setup-shell
@@ -3,7 +3,7 @@
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
 HOME_DIR=/home/replicant
-source /etc/profile.d/header.sh
+source /etc/profile/header.sh
 
 ### Assure the tmux session exists
 #
@@ -16,9 +16,4 @@ if ! tmux has-session -t shell ; then
   tmux new-session -d -s shell su - replicant
 fi
 
-# Wait for Instruqt bootstrap to be complete
-while [ ! -f /opt/instruqt/bootstrap/host-bootstrap-completed ]
-do
-  echo "Waiting for Instruqt to finish booting the VM"
-  sleep 1
-done
+exit 0

--- a/instruqt/shared-env-template/03-tips-and-tricks/setup-shell
+++ b/instruqt/shared-env-template/03-tips-and-tricks/setup-shell
@@ -3,7 +3,7 @@
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
 HOME_DIR=/home/replicant
-source /etc/profile/header.sh
+source /etc/profile.d/header.sh
 
 ### Assure the tmux session exists
 #

--- a/instruqt/shared-env-template/03-tips-and-tricks/solve-cluster
+++ b/instruqt/shared-env-template/03-tips-and-tricks/solve-cluster
@@ -2,11 +2,7 @@
 
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
-HOME_DIR=/home/replicant
 source /etc/profile/header.sh
-
-# clear the tmux pane and scrollback to look like a fresh shell
-tmux clear-history -t shell 
-tmux send-keys -t shell clear ENTER
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 
 exit 0

--- a/instruqt/shared-env-template/03-tips-and-tricks/solve-cluster
+++ b/instruqt/shared-env-template/03-tips-and-tricks/solve-cluster
@@ -2,7 +2,7 @@
 
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
-source /etc/profile/header.sh
+source /etc/profile.d/header.sh
 export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 
 exit 0

--- a/instruqt/shared-env-template/03-tips-and-tricks/solve-shell
+++ b/instruqt/shared-env-template/03-tips-and-tricks/solve-shell
@@ -3,6 +3,6 @@
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
 HOME_DIR=/home/replicant
-source /etc/profile/header.sh
+source /etc/profile.d/header.sh
 
 exit 0

--- a/instruqt/shared-env-template/03-tips-and-tricks/solve-shell
+++ b/instruqt/shared-env-template/03-tips-and-tricks/solve-shell
@@ -3,9 +3,6 @@
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
 HOME_DIR=/home/replicant
-#
-# clear the tmux pane and scrollback to look like a fresh shell
-tmux clear-history -t shell 
-tmux send-keys -t shell clear ENTER
+source /etc/profile/header.sh
 
 exit 0

--- a/instruqt/shared-env-template/config.yml
+++ b/instruqt/shared-env-template/config.yml
@@ -5,6 +5,6 @@ containers:
   shell: tmux new-session -A -s shell su - replicant
 virtualmachines:
 - name: cluster
-  image: instruqt/k3s-v1-25-0
+  image: instruqt/k3s-v1-29-0
   shell: /bin/bash
   machine_type: n1-standard-1

--- a/instruqt/shared-env-template/track.yml
+++ b/instruqt/shared-env-template/track.yml
@@ -28,10 +28,7 @@ tags:
 owner: replicated
 developers:
 - chuck@replicated.com
-- vladimir@replicated.com
-- beck@replicated.com
-- jackee@replicated.com
 private: false
 published: false
-maintenance: false
+maintenance: true
 checksum: "339424959900277795"

--- a/instruqt/shared-env-template/track.yml
+++ b/instruqt/shared-env-template/track.yml
@@ -25,7 +25,6 @@ description: |-
 icon: https://storage.googleapis.com/instruqt-frontend/img/tracks/default.png
 tags:
 - template
-- builders
 owner: replicated
 developers:
 - chuck@replicated.com

--- a/instruqt/shared-env-template/track.yml
+++ b/instruqt/shared-env-template/track.yml
@@ -25,6 +25,7 @@ description: |-
 icon: https://storage.googleapis.com/instruqt-frontend/img/tracks/default.png
 tags:
 - template
+- builders
 owner: replicated
 developers:
 - chuck@replicated.com

--- a/instruqt/shared-env-template/track.yml
+++ b/instruqt/shared-env-template/track.yml
@@ -28,7 +28,11 @@ tags:
 owner: replicated
 developers:
 - chuck@replicated.com
-private: false
-published: false
 maintenance: true
-checksum: "339424959900277795"
+lab_config:
+  overlay: false
+  width: 25
+  position: right
+  feedback_recap_enabled: true
+  loadingMessages: true
+checksum: "5150027763894795965"

--- a/instruqt/shared-env-template/track_scripts/setup-cluster
+++ b/instruqt/shared-env-template/track_scripts/setup-cluster
@@ -5,6 +5,7 @@ set -euxo pipefail
 
 # use our shared libary in setup scripts
 curl -s -o /etc/profile.d/header.sh https://raw.githubusercontent.com/replicatedhq/kots-field-labs/main/libs/header.sh
+source /etc/profile.d/header.sh
 
 # simple SSH client setup so we can SSH to/from the shell
 cat <<EOF >> "$HOME/.ssh/config"

--- a/instruqt/shared-env-template/track_scripts/setup-cluster
+++ b/instruqt/shared-env-template/track_scripts/setup-cluster
@@ -3,8 +3,10 @@
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
 
-# simple SSH client setup so we can SSH to/from the shell
+# use our shared libary in setup scripts
+curl -s -o /etc/profile.d/header.sh https://raw.githubusercontent.com/replicatedhq/kots-field-labs/main/libs/header.sh
 
+# simple SSH client setup so we can SSH to/from the shell
 cat <<EOF >> "$HOME/.ssh/config"
 Host *
     StrictHostKeyChecking no

--- a/instruqt/shared-env-template/track_scripts/setup-shell
+++ b/instruqt/shared-env-template/track_scripts/setup-shell
@@ -2,9 +2,12 @@
 
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
+HOME_DIR=/home/replicant
+
+# use our shared libary in setup scripts
+curl -s -o /etc/profile.d/header.sh https://raw.githubusercontent.com/replicatedhq/kots-field-labs/main/libs/header.sh
 
 # simple SSH client setup so we can SSH to/from the shell
-
 cat <<EOF >> "$HOME/.ssh/config"
 Host *
     StrictHostKeyChecking no
@@ -15,5 +18,5 @@ EOF
 ssh-keygen -t rsa -f /etc/dropbear/dropbear_rsa_host_key -N ''
 
 # change the cluster URI
-yq -i '.clusters[0].cluster.server = "https://cluster:6443"' /home/replicant/.kube/config
-chown -R replicant /home/replicant/.kube
+yq -i '.clusters[0].cluster.server = "https://cluster:6443"' ${HOME_DIR}/.kube/config
+chown -R replicant ${HOME_DIR}/.kube

--- a/instruqt/shared-env-template/track_scripts/setup-shell
+++ b/instruqt/shared-env-template/track_scripts/setup-shell
@@ -5,7 +5,7 @@ set -euxo pipefail
 HOME_DIR=/home/replicant
 
 # use our shared libary in setup scripts
-curl -s -o /etc/profile.d/header.sh https://raw.githubusercontent.com/replicatedhq/kots-field-labs/main/libs/header.sh
+curl -s -o /etc/profile.d/header.sh https://raw.githubusercontent.com/replicatedhq/replicated-field-labs/chore/crdant/refines-template/libs/header.sh
 source /etc/profile.d/header.sh
 
 # simple SSH client setup so we can SSH to/from the shell

--- a/instruqt/shared-env-template/track_scripts/setup-shell
+++ b/instruqt/shared-env-template/track_scripts/setup-shell
@@ -6,6 +6,7 @@ HOME_DIR=/home/replicant
 
 # use our shared libary in setup scripts
 curl -s -o /etc/profile.d/header.sh https://raw.githubusercontent.com/replicatedhq/kots-field-labs/main/libs/header.sh
+source /etc/profile.d/header.sh
 
 # simple SSH client setup so we can SSH to/from the shell
 cat <<EOF >> "$HOME/.ssh/config"
@@ -20,3 +21,14 @@ ssh-keygen -t rsa -f /etc/dropbear/dropbear_rsa_host_key -N ''
 # change the cluster URI
 yq -i '.clusters[0].cluster.server = "https://cluster:6443"' ${HOME_DIR}/.kube/config
 chown -R replicant ${HOME_DIR}/.kube
+
+# set up some variables that are needed in most labs
+
+# there's only one app created by the automation, so just grab the first in the list
+access_token=$(get_api_token)
+app_slug=$(get_app_slug)
+
+agent variable set USERNAME $(get_username)
+agent variable set PASSWORD $(get_password)
+agent variable set REPLICATED_API_TOKEN ${access_token}
+agent variable set REPLICATED_APP ${app_slug}

--- a/libs/header.sh
+++ b/libs/header.sh
@@ -47,4 +47,5 @@ get_app_slug () {
   application=${1:-"Slackernews"}
   access_token=$(get_api_token)
   app_slug=$(curl --header 'Accept: application/json' --header "Authorization: ${access_token}" https://api.replicated.com/vendor/v3/apps | jq -r --arg application ${application} '.apps[] | select( .name | startswith( $application )) | .slug')
+  echo ${app_slug}
 }

--- a/libs/header.sh
+++ b/libs/header.sh
@@ -46,5 +46,5 @@ get_api_token () {
 get_app_slug () {
   application=${1:-"Slackernews"}
   access_token=$(get_api_token)
-  app_slug=$(curl --header 'Accept: application/json' --header "Authorization: ${access_token}" https://api.replicated.com/vendor/v3/apps | jq -r --arg application ${application} '.apps[] | select( .name == $application ) | .slug')
+  app_slug=$(curl --header 'Accept: application/json' --header "Authorization: ${access_token}" https://api.replicated.com/vendor/v3/apps | jq -r --arg application ${application} '.apps[] | select( .name | startswith( $application )) | .slug')
 }

--- a/libs/header.sh
+++ b/libs/header.sh
@@ -42,3 +42,9 @@ get_api_token () {
 
   echo ${access_token}
 }
+
+get_app_slug () {
+  application=${1:-"Slackernews"}
+  access_token=$(get_api_token)
+  app_slug=$(curl --header 'Accept: application/json' --header "Authorization: ${access_token}" https://api.replicated.com/vendor/v3/apps | jq -r '| jq -r --arg application ${application} '.apps[] | select( .name == $application ) | .slug')
+}

--- a/libs/header.sh
+++ b/libs/header.sh
@@ -46,5 +46,5 @@ get_api_token () {
 get_app_slug () {
   application=${1:-"Slackernews"}
   access_token=$(get_api_token)
-  app_slug=$(curl --header 'Accept: application/json' --header "Authorization: ${access_token}" https://api.replicated.com/vendor/v3/apps | jq -r '| jq -r --arg application ${application} '.apps[] | select( .name == $application ) | .slug')
+  app_slug=$(curl --header 'Accept: application/json' --header "Authorization: ${access_token}" https://api.replicated.com/vendor/v3/apps | jq -r --arg application ${application} '.apps[] | select( .name == $application ) | .slug')
 }


### PR DESCRIPTION
TL;DR
-----

Improves the shared environment template based on recent lab work

Details
-------

Updates the shared environment template based on recurring lifecycle
script needs.

* Bumps Kubernetes version to 1.29.0
* Includes the header in all lifecycle scripts
* Updates maintainers and starts the track in maintenance mode
* Assures all challenges have the minimal lifecycle scripts for each
  stage and host
* Uses `/usr/bin/env bash` as the shebang for all lifecycle scripts
* Sets `KUBECONFIG` or `HOME_DIR` variables  at the start of each
  lifecycle script
* Sets the most used agent variables in the track setup scripts
* Adds `get_app_slug` to the header and refines it to use the
  application name instead of assuming the first app is the right one
* Gets rid of old bash output of credentials since we can use instruqt variables for it.