### PR TITLE
Corrects merge issue for header download

### DIFF
--- a/instruqt/shared-env-template/track_scripts/setup-cluster
+++ b/instruqt/shared-env-template/track_scripts/setup-cluster
@@ -4,7 +4,7 @@
 set -euxo pipefail
 
 # use our shared libary in setup scripts
-curl -s -o /etc/profile.d/header.sh https://raw.githubusercontent.com/replicatedhq/kots-field-labs/main/libs/header.sh
+curl -s -o /etc/profile.d/header.sh https://raw.githubusercontent.com/replicatedhq/replicated-field-labs/main/libs/header.sh
 source /etc/profile.d/header.sh
 
 # simple SSH client setup so we can SSH to/from the shell

--- a/instruqt/shared-env-template/track_scripts/setup-shell
+++ b/instruqt/shared-env-template/track_scripts/setup-shell
@@ -5,7 +5,7 @@ set -euxo pipefail
 HOME_DIR=/home/replicant
 
 # use our shared libary in setup scripts
-curl -s -o /etc/profile.d/header.sh https://raw.githubusercontent.com/replicatedhq/replicated-field-labs/chore/crdant/refines-template/libs/header.sh
+curl -s -o /etc/profile.d/header.sh https://raw.githubusercontent.com/replicatedhq/replicated-field-labs/main/libs/header.sh
 source /etc/profile.d/header.sh
 
 # simple SSH client setup so we can SSH to/from the shell


### PR DESCRIPTION
TL;DR
-----

Fixes an issue with were the branch header was being downloaded

Details
-------

The last updates the template got merged in with the header download in
the track setup script referring to the branch. Once the branch was
deleted it couldn't be downloaded any longer. This change fixes that.
