### PR TITLE
Promote Slackernews Labs to production

### DIFF
--- a/instruqt/avoiding-installation-pitfalls/01-working-with-preflight-checks/assignment.md
+++ b/instruqt/avoiding-installation-pitfalls/01-working-with-preflight-checks/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: working-with-preflight-checks
-id: drqyyxcvdzxz
+id: pb1gr26u3om3
 type: challenge
 title: Working with Preflight Checks
 teaser: |-

--- a/instruqt/avoiding-installation-pitfalls/02-checking-cluster-resources/assignment.md
+++ b/instruqt/avoiding-installation-pitfalls/02-checking-cluster-resources/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: checking-cluster-resources
-id: tcwpxsj6yplu
+id: jn3ywr8xtchw
 type: challenge
 title: Checking Cluster Resources
 teaser: Use preflight checks to validate minimum cluster requirements

--- a/instruqt/avoiding-installation-pitfalls/03-adding-preflights-to-the-chart/assignment.md
+++ b/instruqt/avoiding-installation-pitfalls/03-adding-preflights-to-the-chart/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: adding-preflights-to-the-chart
-id: vwxcejaonowy
+id: dxquyvsyuojv
 type: challenge
 title: Adding Preflights to the Slackernews Helm Chart
 teaser: Learn how to incorporate your preflight checks into your chart

--- a/instruqt/avoiding-installation-pitfalls/04-releasing-the-application/assignment.md
+++ b/instruqt/avoiding-installation-pitfalls/04-releasing-the-application/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: releasing-the-application
-id: q5wbycoymxhk
+id: atrybjwrgxfh
 type: challenge
 title: Releasing the Application
 teaser: Releasing with preflights on the Replicated Platform

--- a/instruqt/avoiding-installation-pitfalls/05-validating-before-an-install/assignment.md
+++ b/instruqt/avoiding-installation-pitfalls/05-validating-before-an-install/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: validating-before-an-install
-id: esalpc0nrb1q
+id: bxilvoxbkmfz
 type: challenge
 title: Validating Before an Install
 teaser: How your customer uses preflights to validate their environment

--- a/instruqt/avoiding-installation-pitfalls/06-completing-the-install/assignment.md
+++ b/instruqt/avoiding-installation-pitfalls/06-completing-the-install/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: completing-the-install
-id: qo2vdg2dfuq4
+id: zwojuzyxhzsq
 type: challenge
 title: Completing the Install
 teaser: Finishing the install once the cluster passes its preflights

--- a/instruqt/avoiding-installation-pitfalls/06-completing-the-install/solve-shell
+++ b/instruqt/avoiding-installation-pitfalls/06-completing-the-install/solve-shell
@@ -7,7 +7,7 @@ app_slug=$(agent variable get REPLICATED_APP)
 helm registry login $(agent variable get REGISTRY_HOST) --username $(agent variable get REGISTRY_USERNAME)  --password $(agent variable get REGISTRY_PASSWORD)
 
 helm install --namespace slackernews --create-namespace \
-  slackernews --version 0.5.1 \
+  slackernews --version 0.3.0 \
   oci://$(agent variable get REGISTRY_HOST)/${app_slug}/slackernews \
   --set nginx.service.type=NodePort --set nginx.service.nodePort.port=30443 \
   --set slackernews.domain=cluster-30443-${INSTRUQT_PARTICIPANT_ID}.env.play.instruqt.com \

--- a/instruqt/avoiding-installation-pitfalls/track.yml
+++ b/instruqt/avoiding-installation-pitfalls/track.yml
@@ -1,6 +1,6 @@
-slug: avoiding-installation-pitfalls-dev
+slug: avoiding-installation-pitfalls
 id: yjxpxhujcxvy
-title: DEV - Avoiding Installation Pitfalls
+title: Avoiding Installation Pitfalls
 teaser: |-
   Use Preflight checks to avoid common installation pitfalls
   for your application

--- a/instruqt/avoiding-installation-pitfalls/track.yml
+++ b/instruqt/avoiding-installation-pitfalls/track.yml
@@ -1,5 +1,5 @@
 slug: avoiding-installation-pitfalls
-id: yjxpxhujcxvy
+id: amjfqroa5bfk
 title: Avoiding Installation Pitfalls
 teaser: |-
   Use Preflight checks to avoid common installation pitfalls
@@ -22,7 +22,6 @@ tags:
 - builders-plan
 - troubleshoot
 - helm
-- dev
 owner: replicated
 developers:
 - chuck@replicated.com
@@ -33,4 +32,4 @@ lab_config:
   position: right
   feedback_recap_enabled: true
   loadingMessages: true
-checksum: "3286430125722429230"
+checksum: "17725433940201648777"

--- a/instruqt/closing-information-gap/01-viewing-instance-info/assignment.md
+++ b/instruqt/closing-information-gap/01-viewing-instance-info/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: viewing-instance-info
-id: x1ai6fxjrnr2
+id: b8a1bj7ffosj
 type: challenge
 title: Getting a Picture of a Customer Instance
 teaser: Using the Replicated Platform to understand details of a customer instance

--- a/instruqt/closing-information-gap/02-working-with-support-bundles/assignment.md
+++ b/instruqt/closing-information-gap/02-working-with-support-bundles/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: working-with-support-bundles
-id: yrkfij51yo0s
+id: tydgy4bvf33n
 type: challenge
 title: Working with Support Bundles
 teaser: |-

--- a/instruqt/closing-information-gap/03-additional-information/assignment.md
+++ b/instruqt/closing-information-gap/03-additional-information/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: additional-information
-id: 75d5lqco04iw
+id: lorzhundumdj
 type: challenge
 title: Collecting and Analyzing Additional Information
 teaser: |

--- a/instruqt/closing-information-gap/04-adding-to-the-chart/assignment.md
+++ b/instruqt/closing-information-gap/04-adding-to-the-chart/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: adding-to-the-chart
-id: oabxrqklmmop
+id: wimuy9m224ls
 type: challenge
 title: Adding the Support Bundle to the Slackernews Helm Chart
 teaser: Learn how to incorporate your support bundle into your chart

--- a/instruqt/closing-information-gap/05-releasing-an-update/assignment.md
+++ b/instruqt/closing-information-gap/05-releasing-an-update/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: releasing-an-update
-id: bb2ckqmiideb
+id: ywybr4uyhntr
 type: challenge
 title: Releasing an Update with the Support Bundle
 teaser: Releasing a new version with the support bundle included

--- a/instruqt/closing-information-gap/06-support-bundle-diagnosis/assignment.md
+++ b/instruqt/closing-information-gap/06-support-bundle-diagnosis/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: support-bundle-diagnosis
-id: 95wkhwxqvww2
+id: rodjcnqzhonq
 type: challenge
 title: Using the Support Bundle to Diagnose the Issue
 teaser: Discover the cause of Geeglo's outage using a support bundle

--- a/instruqt/closing-information-gap/07-other-ways/assignment.md
+++ b/instruqt/closing-information-gap/07-other-ways/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: other-ways
-id: ccdxc6g7q55t
+id: 8acmsy6ralcy
 type: challenge
 title: Other Ways to Offer a Support Bundle
 teaser: Explore other ways to distibute your support bundle and keep it up to date

--- a/instruqt/closing-information-gap/track.yml
+++ b/instruqt/closing-information-gap/track.yml
@@ -1,5 +1,5 @@
 slug: closing-information-gap
-id: 04xwdzyvx0ya
+id: hfb41xqkyx0q
 title: Closing the Support Information Gap
 teaser: |-
   Use the Replicated Platform to close the information gap between your
@@ -22,7 +22,6 @@ tags:
 - builders-plan
 - troubleshoot
 - helm
-- dev
 owner: replicated
 developers:
 - chuck@replicated.com
@@ -33,4 +32,4 @@ lab_config:
   position: right
   feedback_recap_enabled: true
   loadingMessages: true
-checksum: "12500015225100159592"
+checksum: "1869930288353195066"

--- a/instruqt/closing-information-gap/track.yml
+++ b/instruqt/closing-information-gap/track.yml
@@ -1,6 +1,6 @@
-slug: closing-information-gap-dev
+slug: closing-information-gap
 id: 04xwdzyvx0ya
-title: DEV - Closing the Support Information Gap
+title: Closing the Support Information Gap
 teaser: |-
   Use the Replicated Platform to close the information gap between your
   customers and your support team

--- a/instruqt/distributing-with-replicated/01-preparing-to-use-the-sdk/assignment.md
+++ b/instruqt/distributing-with-replicated/01-preparing-to-use-the-sdk/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: preparing-to-use-the-sdk
-id: 2fnokww9qrc2
+id: ulkfmbpkhe3y
 type: challenge
 title: Preparing to Use the SDK
 teaser: Getting ready to use the Replicated SDK

--- a/instruqt/distributing-with-replicated/02-enabling-the-sdk/assignment.md
+++ b/instruqt/distributing-with-replicated/02-enabling-the-sdk/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: enabling-the-sdk
-id: uqhupnwrlny3
+id: 9weportqrwy6
 type: challenge
 title: Enabling the Replicated SDK
 teaser: Incorporate the SDK into your application

--- a/instruqt/distributing-with-replicated/03-creating-a-release/assignment.md
+++ b/instruqt/distributing-with-replicated/03-creating-a-release/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: creating-a-release
-id: eqwg3rmrwopo
+id: vxnhm8nlkifh
 type: challenge
 title: Releasing an Application
 teaser: Creating a release on the Replicated Platform

--- a/instruqt/distributing-with-replicated/04-installing-the-application/assignment.md
+++ b/instruqt/distributing-with-replicated/04-installing-the-application/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: installing-the-application
-id: ooympxisag7r
+id: 7tugkh1lkicg
 type: challenge
 title: Installing the Application
 teaser: Let's install the application as your customer

--- a/instruqt/distributing-with-replicated/05-validating-the-install/assignment.md
+++ b/instruqt/distributing-with-replicated/05-validating-the-install/assignment.md
@@ -1,6 +1,6 @@
 ---
 slug: validating-the-install
-id: yvvw2mtonkvv
+id: gx3ctjxdgybf
 type: challenge
 title: Observing the Customer Instance
 teaser: Observing your customer install

--- a/instruqt/distributing-with-replicated/track.yml
+++ b/instruqt/distributing-with-replicated/track.yml
@@ -1,6 +1,6 @@
-slug: distributing-with-replicated-dev
+slug: distributing-with-replicated
 id: dqxwnogzxxfv
-title: DEV - Distributing Your Application with Replicated
+title: Distributing Your Application with Replicated
 description: |-
   Learn how to quickly take advantage of the Replicated Platform for
   your application. We'll take an existing Helm chart, add a dependency
@@ -28,4 +28,4 @@ lab_config:
   position: right
   feedback_recap_enabled: true
   loadingMessages: true
-checksum: "14491965674312593548"
+checksum: "2622909899588700505"

--- a/instruqt/distributing-with-replicated/track.yml
+++ b/instruqt/distributing-with-replicated/track.yml
@@ -1,5 +1,5 @@
 slug: distributing-with-replicated
-id: dqxwnogzxxfv
+id: evmpzv6ycpgs
 title: Distributing Your Application with Replicated
 description: |-
   Learn how to quickly take advantage of the Replicated Platform for
@@ -16,7 +16,6 @@ level: beginner
 tags:
 - builders-plan
 - helm
-- dev
 - sdk
 owner: replicated
 developers:
@@ -28,4 +27,4 @@ lab_config:
   position: right
   feedback_recap_enabled: true
   loadingMessages: true
-checksum: "2622909899588700505"
+checksum: "7911887612029781210"


### PR DESCRIPTION
TL;DR
-----

Moves the Slackernews replacements for Harbor labs to production

Details
-------

Update the track metadata to deploy the three labs original written around the Harbor registry to use Slackernews.

Covers the following labs:

* Distributing Your Application with Replicated
* Avoiding Installation Pitfalls
* Closing the Support Information Gap
