### PR TITLE
update checkout action to v4

### DIFF
--- a/.github/workflows/build-jumpbox-image.yaml
+++ b/.github/workflows/build-jumpbox-image.yaml
@@ -14,7 +14,7 @@ on:
     paths:
     - 'packer/jumpbox/**'
     - .github/workflows/build-jumpbox-image.yaml
- 
+
 jobs:
   build_and_push_jumpbox:
     name: Build Jumpbox GCP Compute Image
@@ -23,7 +23,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Authenicate to Google Cloud
       uses: google-github-actions/auth@v0
@@ -60,7 +60,7 @@ jobs:
     # build artifact for push/merge (use default name)
     - name: Build VM Image
       uses: hashicorp/packer-github-actions@master
-      if: ${{ github.event_name != 'pull_request' }} 
+      if: ${{ github.event_name != 'pull_request' }}
       with:
         command: build
         arguments: "-force"
@@ -71,11 +71,11 @@ jobs:
         PKR_VAR_service_account_key: ${{secrets.GCP_SERVICE_ACCOUNT_KEY}}
         PKR_VAR_zone: europe-west1-b
         PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
+
     # build artifact for PRs (need to assign image name)
     - name: Build VM Image
       uses: hashicorp/packer-github-actions@master
-      if: ${{ github.event_name == 'pull_request' }} 
+      if: ${{ github.event_name == 'pull_request' }}
       with:
         command: build
         arguments: "-force"
@@ -86,9 +86,9 @@ jobs:
         PKR_VAR_service_account_key: ${{secrets.GCP_SERVICE_ACCOUNT_KEY}}
         PKR_VAR_image_name: airgap-jumpbox-${{github.sha}}
         PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
+
     # delete built artifact for PRs (save storage costs)
     - name: Delete VM Image
-      if: ${{ github.event_name == 'pull_request' }} 
+      if: ${{ github.event_name == 'pull_request' }}
       run: gcloud compute images delete --quiet airgap-jumpbox-${{github.sha}}
       shell: bash

--- a/.github/workflows/build-shell-image.yaml
+++ b/.github/workflows/build-shell-image.yaml
@@ -26,7 +26,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Authenicate to Google Cloud
       uses: google-github-actions/auth@v2
@@ -71,7 +71,7 @@ jobs:
     - name: Build and Push to Google Container Registry
       uses: docker/build-push-action@v3
       with:
-        context: docker/shell 
+        context: docker/shell
         platforms: linux/amd64
         push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/instruqt-create-dev-track.yml
+++ b/.github/workflows/instruqt-create-dev-track.yml
@@ -9,19 +9,19 @@ name: instruqt-create-dev
 env:
   INSTRUQT_TOKEN: ${{ secrets.INSTRUQT_TOKEN }}
   TRACK_DIR: instruqt
-  
+
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-on: 
+on:
   workflow_dispatch:
     inputs:
       slug:
         description: Track Slug
         required: true
         type: string
-    branches:    
+    branches:
       - '!main'
       - '!master'
 
@@ -31,7 +31,7 @@ jobs:
     steps:
 
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Create dev track
         uses: ./.github/actions/track-dev

--- a/.github/workflows/instruqt-dev-track-test.yml
+++ b/.github/workflows/instruqt-dev-track-test.yml
@@ -10,8 +10,8 @@
 name: Test Development Track
 
 env:
-  # Set these values to match your environment. Your token should be 
-  # stored as a Github secret in your tracks repo. Also make sure you 
+  # Set these values to match your environment. Your token should be
+  # stored as a Github secret in your tracks repo. Also make sure you
   # have a track-slugs.yml file in your tracks directory.
   TRACK_DIR: instruqt
   INSTRUQT_TOKEN: ${{ secrets.INSTRUQT_TOKEN }}
@@ -30,11 +30,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out repository code
-      uses: actions/checkout@v3
-    
+      uses: actions/checkout@v4
+
     - name: Install yq Package
       uses: ./.github/actions/install-yq
-    
+
     - name: Create Matrix Data
       run: echo "TRACKS=$(yq -o j $TRACK_DIR/track-slugs.yml | jq tostring | sed -e 's/^"//' -e 's/"$//')" >> $GITHUB_ENV
 
@@ -51,12 +51,12 @@ jobs:
       matrix: ${{ fromJson(needs.GetTrackSlugs.outputs.matrix) }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
-        
+        uses: actions/checkout@v4
+
       - name: Install yq Package
         uses: ./.github/actions/install-yq
 
-      - name: Convert to DEV version 
+      - name: Convert to DEV version
         uses: ./.github/actions/track-dev
         with:
           path: ${{ env.TRACK_DIR }}/${{ matrix.tracks.slug }}
@@ -68,13 +68,13 @@ jobs:
         with:
           path: ${{ env.TRACK_DIR }}/${{ matrix.tracks.slug }}
         continue-on-error: true
-        
+
       - name: Track Validate
         uses: ./.github/actions/track-validate
         with:
           path: ${{ env.TRACK_DIR }}/${{ matrix.tracks.slug }}
         if: steps.track-pull.outcome == 'success'
-      
+
       - name: Track Test
         uses: ./.github/actions/track-test
         with:

--- a/.github/workflows/instruqt-generate-track-slugs.yml
+++ b/.github/workflows/instruqt-generate-track-slugs.yml
@@ -9,12 +9,12 @@ name: instruqt-generate
 env:
   INSTRUQT_TOKEN: ${{ secrets.INSTRUQT_TOKEN }}
   TRACK_DIR: instruqt
-  
+
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-on: 
+on:
   workflow_dispatch:
   pull_request:
     types:
@@ -26,7 +26,7 @@ jobs:
     steps:
 
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Find track descriptors
         id: find-track-descriptors

--- a/.github/workflows/instruqt-prod-track-test.yml
+++ b/.github/workflows/instruqt-prod-track-test.yml
@@ -10,8 +10,8 @@
 name: Test Production Tracks
 
 env:
-  # Set these values to match your environment. Your token should be 
-  # stored as a Github secret in your tracks repo. Also make sure you 
+  # Set these values to match your environment. Your token should be
+  # stored as a Github secret in your tracks repo. Also make sure you
   # have a track-slugs.yml file in your tracks directory.
   TRACK_DIR: instruqt
   INSTRUQT_TOKEN: ${{ secrets.INSTRUQT_TOKEN }}
@@ -36,8 +36,8 @@ jobs:
     steps:
 
     - name: Check out repository code
-      uses: actions/checkout@v3
-    
+      uses: actions/checkout@v4
+
     - name: Install yq Package
       uses: ./.github/actions/install-yq
 
@@ -69,7 +69,7 @@ jobs:
     steps:
 
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # This step checks for the "no-ci" tag on a track
       # If the tag is not present, this step succeeds
@@ -86,13 +86,13 @@ jobs:
         with:
           path: ${{ env.TRACK_DIR }}/${{ matrix.tracks.slug }}
         if: steps.check-ci.outcome == 'success'
-      
+
       - name: Track Push
         uses: ./.github/actions/track-push
         with:
           path: ${{ env.TRACK_DIR }}/${{ matrix.tracks.slug }}
         if: steps.check-ci.outcome == 'success'
-      
+
       - name: Instruqt Track Test
         uses: ./.github/actions/track-test
         with:

--- a/.github/workflows/instruqt-promote-dev-track.yml
+++ b/.github/workflows/instruqt-promote-dev-track.yml
@@ -9,19 +9,19 @@ name: Promote Development Track to Production
 env:
   INSTRUQT_TOKEN: ${{ secrets.INSTRUQT_TOKEN }}
   TRACK_DIR: instruqt
-  
+
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-on: 
+on:
   workflow_dispatch:
     inputs:
       slug:
         description: Track Slug
         required: true
         type: string
-    branches:    
+    branches:
       - '!main'
       - '!master'
 
@@ -32,7 +32,7 @@ jobs:
     steps:
 
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Pull latest track
         uses: ./.github/actions/track-pull


### PR DESCRIPTION
Resolves nodejs 16 deprecation warnings:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20
