### PR TITLE
Bumps up unnaturally short time limit

### DIFF
--- a/instruqt/distributing-with-replicated/track.yml
+++ b/instruqt/distributing-with-replicated/track.yml
@@ -12,7 +12,6 @@ description: |-
    * Prepare customer entitlements
    * Understand your customer's application instance
 icon: https://storage.googleapis.com/shared-lab-assets/icons/red/appslug.png
-level: beginner
 tags:
 - builders-plan
 - helm
@@ -20,11 +19,13 @@ tags:
 owner: replicated
 developers:
 - chuck@replicated.com
-timelimit: 600
+timelimit: 2100
 lab_config:
   overlay: false
   width: 33
   position: right
   feedback_recap_enabled: true
   loadingMessages: true
-checksum: "7911887612029781210"
+  lab_v2: false
+  hideStopButton: false
+checksum: "3447726368566940438"


### PR DESCRIPTION
TL;DR
-----

Fixes time limit on Distributing Your Application with Replicated

Details
-------

At some point along the way, I misunderstood which file I was working in
and ended up setting the timeout for the entire "Distributing Your
Application with Replicated" lab to ten minutes. This change addresses
that.
