### PR TITLE
Removes EC lab from production tests

### DIFF
--- a/instruqt/track-slugs.yml
+++ b/instruqt/track-slugs.yml
@@ -17,7 +17,5 @@ tracks:
     id: 1gpba3eivmb4
   - slug: avoiding-installation-pitfalls
     id: amjfqroa5bfk
-  - slug: delivering-as-an-appliance
-    id: pbzwbwd3m2aw
   - slug: protecting-your-assets
     id: zvnn71s6vwuk


### PR DESCRIPTION
TL;DR
-----

Stops test from overwriting beta lab

Details
-------

The periodic tests we run on the live labs have been overwriting the
beta lab for "Delivering Your Application as a Kubernetes Appliance" and
we can't have that. This fix moves that lab out of the testing
temporarily.
