### PR TITLE
Corrects regression in setup scripts that fetch the SDK version

### DIFF
--- a/instruqt/avoiding-installation-pitfalls/01-working-with-preflight-checks/assignment.md
+++ b/instruqt/avoiding-installation-pitfalls/01-working-with-preflight-checks/assignment.md
@@ -10,10 +10,12 @@ notes:
 - type: text
   contents: Let's learn about Preflights
 tabs:
-- title: Shell
+- id: mrf6knj0wyfn
+  title: Shell
   type: terminal
   hostname: shell
-- title: Manifest Editor
+- id: xze3brnl78ss
+  title: Manifest Editor
   type: code
   hostname: shell
   path: /home

--- a/instruqt/avoiding-installation-pitfalls/02-checking-cluster-resources/assignment.md
+++ b/instruqt/avoiding-installation-pitfalls/02-checking-cluster-resources/assignment.md
@@ -8,10 +8,12 @@ notes:
 - type: text
   contents: Making sure a cluster has sufficient resources to run your application
 tabs:
-- title: Shell
+- id: tkmoixrrxpfp
+  title: Shell
   type: terminal
   hostname: shell
-- title: Manifest Editor
+- id: qorzyzbpqu6g
+  title: Manifest Editor
   type: code
   hostname: shell
   path: /home/replicant

--- a/instruqt/avoiding-installation-pitfalls/03-adding-preflights-to-the-chart/assignment.md
+++ b/instruqt/avoiding-installation-pitfalls/03-adding-preflights-to-the-chart/assignment.md
@@ -8,10 +8,12 @@ notes:
 - type: text
   contents: Time to add our preflight checks to the Slackernews Helm chart
 tabs:
-- title: Shell
+- id: 8jjygkef146j
+  title: Shell
   type: terminal
   hostname: shell
-- title: Manifest Editor
+- id: bjyujpl2opc6
+  title: Manifest Editor
   type: code
   hostname: shell
   path: /home/replicant

--- a/instruqt/avoiding-installation-pitfalls/04-releasing-the-application/assignment.md
+++ b/instruqt/avoiding-installation-pitfalls/04-releasing-the-application/assignment.md
@@ -8,7 +8,8 @@ notes:
 - type: text
   contents: Time to release an update with our preflight checks
 tabs:
-- title: Shell
+- id: hue1wtnboudc
+  title: Shell
   type: terminal
   hostname: shell
 difficulty: basic

--- a/instruqt/avoiding-installation-pitfalls/05-validating-before-an-install/assignment.md
+++ b/instruqt/avoiding-installation-pitfalls/05-validating-before-an-install/assignment.md
@@ -8,10 +8,12 @@ notes:
 - type: text
   contents: Experience how your customer executes your preflight checks
 tabs:
-- title: Shell
+- id: rszt3nfzheah
+  title: Shell
   type: terminal
   hostname: shell
-- title: Vendor Portal
+- id: 8hyv0jpufvyq
+  title: Vendor Portal
   type: website
   url: https://vendor.replicated.com
   new_window: true

--- a/instruqt/avoiding-installation-pitfalls/06-completing-the-install/assignment.md
+++ b/instruqt/avoiding-installation-pitfalls/06-completing-the-install/assignment.md
@@ -8,14 +8,17 @@ notes:
 - type: text
   contents: Completing the installation when cluster capacity is increased
 tabs:
-- title: Shell
+- id: hvpbi534iipc
+  title: Shell
   type: terminal
   hostname: shell
-- title: Vendor Portal
+- id: so6uwiwpvwam
+  title: Vendor Portal
   type: website
   url: https://vendor.replicated.com
   new_window: true
-- title: Slackernews
+- id: 8f7zxmrg2vcw
+  title: Slackernews
   type: service
   hostname: cluster
   port: 30443

--- a/instruqt/avoiding-installation-pitfalls/track.yml
+++ b/instruqt/avoiding-installation-pitfalls/track.yml
@@ -37,4 +37,4 @@ lab_config:
   hideStopButton: false
   default_layout: AssignmentRight
   default_layout_sidebar_size: 33
-checksum: "4859232265819446213"
+checksum: "5603234607182338828"

--- a/instruqt/avoiding-installation-pitfalls/track.yml
+++ b/instruqt/avoiding-installation-pitfalls/track.yml
@@ -30,6 +30,11 @@ lab_config:
   overlay: false
   width: 33
   position: right
+  sidebar_enabled: true
   feedback_recap_enabled: true
+  feedback_tab_enabled: false
   loadingMessages: true
-checksum: "17725433940201648777"
+  hideStopButton: false
+  default_layout: AssignmentRight
+  default_layout_sidebar_size: 33
+checksum: "4859232265819446213"

--- a/instruqt/avoiding-installation-pitfalls/track_scripts/setup-shell
+++ b/instruqt/avoiding-installation-pitfalls/track_scripts/setup-shell
@@ -35,7 +35,7 @@ get_slackernews
 yq -i '.version = "0.2.0"' slackernews/Chart.yaml
 replicated_sdk_version=$(get_replicated_sdk_version)
 yq -i ".dependencies += []" slackernews/Chart.yaml
-yq -i ".dependencies += { \"name\": \"replicated\", \"repository\": \"oci://registry.replicated.com/library\", \"version\": \"${replicated_sdk_version#?}\"}" slackernews/Chart.yaml
+yq -i ".dependencies += { \"name\": \"replicated\", \"repository\": \"oci://registry.replicated.com/library\", \"version\": \"${replicated_sdk_version}\"}" slackernews/Chart.yaml
 
 # update dependencies
 helm dependency update slackernews

--- a/instruqt/closing-information-gap/01-viewing-instance-info/assignment.md
+++ b/instruqt/closing-information-gap/01-viewing-instance-info/assignment.md
@@ -8,7 +8,8 @@ notes:
 - type: text
   contents: Establish instant context when a support request comes in
 tabs:
-- title: Vendor Portal
+- id: njr2qrhr1amp
+  title: Vendor Portal
   type: website
   url: https://vendor.replicated.com
   new_window: true

--- a/instruqt/closing-information-gap/02-working-with-support-bundles/assignment.md
+++ b/instruqt/closing-information-gap/02-working-with-support-bundles/assignment.md
@@ -10,10 +10,12 @@ notes:
 - type: text
   contents: Let's learn about Support Bundles
 tabs:
-- title: Shell
+- id: i3e2bpng3asx
+  title: Shell
   type: terminal
   hostname: shell
-- title: Manifest Editor
+- id: lbfyllzhfkz6
+  title: Manifest Editor
   type: code
   hostname: shell
   path: /home

--- a/instruqt/closing-information-gap/03-additional-information/assignment.md
+++ b/instruqt/closing-information-gap/03-additional-information/assignment.md
@@ -11,10 +11,12 @@ notes:
   contents: |
     Gather and analyze additional information to get a more completed picture
 tabs:
-- title: Shell
+- id: cnpgj5jxyaew
+  title: Shell
   type: terminal
   hostname: shell
-- title: Manifest Editor
+- id: vleuag7nhqbp
+  title: Manifest Editor
   type: code
   hostname: shell
   path: /home/replicant

--- a/instruqt/closing-information-gap/04-adding-to-the-chart/assignment.md
+++ b/instruqt/closing-information-gap/04-adding-to-the-chart/assignment.md
@@ -8,10 +8,12 @@ notes:
 - type: text
   contents: Time to add your support bundle definition to the Slackernews Helm chart
 tabs:
-- title: Shell
+- id: gvcfeq0xolb5
+  title: Shell
   type: terminal
   hostname: shell
-- title: Manifest Editor
+- id: xs2tflck3nhu
+  title: Manifest Editor
   type: code
   hostname: shell
   path: /home/replicant

--- a/instruqt/closing-information-gap/05-releasing-an-update/assignment.md
+++ b/instruqt/closing-information-gap/05-releasing-an-update/assignment.md
@@ -8,7 +8,8 @@ notes:
 - type: text
   contents: Let's create a release to distribute the support bundle
 tabs:
-- title: Shell
+- id: idcf1k25yddg
+  title: Shell
   type: terminal
   hostname: shell
 difficulty: basic

--- a/instruqt/closing-information-gap/06-support-bundle-diagnosis/assignment.md
+++ b/instruqt/closing-information-gap/06-support-bundle-diagnosis/assignment.md
@@ -8,7 +8,8 @@ notes:
 - type: text
   contents: Troubleshooting the unavailable instance using the support bundle
 tabs:
-- title: Shell
+- id: 3empyvcmm8td
+  title: Shell
   type: terminal
   hostname: shell
 difficulty: basic

--- a/instruqt/closing-information-gap/07-other-ways/assignment.md
+++ b/instruqt/closing-information-gap/07-other-ways/assignment.md
@@ -8,10 +8,12 @@ notes:
 - type: text
   contents: How else can you distribute your support bundle
 tabs:
-- title: Shell
+- id: t7gxs2jowsje
+  title: Shell
   type: terminal
   hostname: shell
-- title: Manifest Editor
+- id: e1zxlzigexon
+  title: Manifest Editor
   type: code
   hostname: shell
   path: /home/replicant

--- a/instruqt/closing-information-gap/track.yml
+++ b/instruqt/closing-information-gap/track.yml
@@ -30,6 +30,11 @@ lab_config:
   overlay: false
   width: 33
   position: right
+  sidebar_enabled: true
   feedback_recap_enabled: true
+  feedback_tab_enabled: false
   loadingMessages: true
-checksum: "1869930288353195066"
+  hideStopButton: false
+  default_layout: AssignmentRight
+  default_layout_sidebar_size: 33
+checksum: "10770906990819584233"

--- a/instruqt/closing-information-gap/track.yml
+++ b/instruqt/closing-information-gap/track.yml
@@ -37,4 +37,4 @@ lab_config:
   hideStopButton: false
   default_layout: AssignmentRight
   default_layout_sidebar_size: 33
-checksum: "10770906990819584233"
+checksum: "10403499794541694349"

--- a/instruqt/closing-information-gap/track_scripts/setup-shell
+++ b/instruqt/closing-information-gap/track_scripts/setup-shell
@@ -40,7 +40,7 @@ get_slackernews
 yq -i '.version = "0.2.0"' slackernews/Chart.yaml
 replicated_sdk_version=$(get_replicated_sdk_version)
 yq -i ".dependencies = []" slackernews/Chart.yaml
-yq -i ".dependencies += { \"name\": \"replicated\", \"repository\": \"oci://registry.replicated.com/library\", \"version\": \"${replicated_sdk_version#?}\"}" slackernews/Chart.yaml
+yq -i ".dependencies += { \"name\": \"replicated\", \"repository\": \"oci://registry.replicated.com/library\", \"version\": \"${replicated_sdk_version}\"}" slackernews/Chart.yaml
 
 # update dependencies
 helm dependency update slackernews

--- a/instruqt/protecting-your-assets/01-the-replicated-license/assignment.md
+++ b/instruqt/protecting-your-assets/01-the-replicated-license/assignment.md
@@ -8,7 +8,8 @@ notes:
 - type: text
   contents: Understanding the Replicated license
 tabs:
-- title: License File
+- id: koeopqurczds
+  title: License File
   type: code
   hostname: shell
   path: /home/replicant

--- a/instruqt/protecting-your-assets/02-create-a-customer/assignment.md
+++ b/instruqt/protecting-your-assets/02-create-a-customer/assignment.md
@@ -9,11 +9,13 @@ notes:
   contents: |
     Add a customer to your application and configure their license
 tabs:
-- title: Vendor Portal
+- id: x9hlwddp7jly
+  title: Vendor Portal
   type: website
   url: https://vendor.replicated.com
   new_window: true
-- title: Shell
+- id: gqxwmse9cfru
+  title: Shell
   type: terminal
   hostname: shell
   workdir: /home/replicant

--- a/instruqt/protecting-your-assets/03-proxying-private-images/assignment.md
+++ b/instruqt/protecting-your-assets/03-proxying-private-images/assignment.md
@@ -9,15 +9,18 @@ notes:
   contents: |
     Share your private images without exposting your private registry to your customers
 tabs:
-- title: Vendor Portal
+- id: poakxpyplmkr
+  title: Vendor Portal
   type: website
   url: https://vendor.replicated.com
   new_window: true
-- title: Slackernews Chart
+- id: yxrpecqzosxy
+  title: Slackernews Chart
   type: code
   hostname: shell
   path: /home/replicant
-- title: Shell
+- id: 34ljfxan4eaw
+  title: Shell
   type: terminal
   hostname: shell
   workdir: /home/replicant

--- a/instruqt/protecting-your-assets/04-helm-values-for-license-fields/assignment.md
+++ b/instruqt/protecting-your-assets/04-helm-values-for-license-fields/assignment.md
@@ -8,15 +8,18 @@ notes:
 - type: text
   contents: Let's limit how the capabilities of a trial license for our application
 tabs:
-- title: Shell
+- id: h86j4ktlvfyu
+  title: Shell
   type: terminal
   hostname: shell
   workdir: /home/replicant
-- title: Slackernews Chart
+- id: hh2yemo75vka
+  title: Slackernews Chart
   type: code
   hostname: shell
   path: /home/replicant
-- title: Vendor Portal
+- id: gcyi9rt0jaw7
+  title: Vendor Portal
   type: website
   url: https://vendor.replicated.com
   new_window: true

--- a/instruqt/protecting-your-assets/05-license-entitlements/assignment.md
+++ b/instruqt/protecting-your-assets/05-license-entitlements/assignment.md
@@ -8,7 +8,8 @@ notes:
 - type: text
   contents: Expanding the license for your specific needs
 tabs:
-- title: Vendor Portal
+- id: 4vnaoq4icpw7
+  title: Vendor Portal
   type: website
   url: https://vendor.replicated.com
   new_window: true

--- a/instruqt/protecting-your-assets/06-validating-license-fields/assignment.md
+++ b/instruqt/protecting-your-assets/06-validating-license-fields/assignment.md
@@ -8,7 +8,8 @@ notes:
 - type: text
   contents: Learn how to validate the entitlements we just created
 tabs:
-- title: Shell
+- id: 9xsnahmfmble
+  title: Shell
   type: terminal
   hostname: shell
   workdir: /home/replicant

--- a/instruqt/protecting-your-assets/07-entitlement-metrics/assignment.md
+++ b/instruqt/protecting-your-assets/07-entitlement-metrics/assignment.md
@@ -10,11 +10,13 @@ notes:
   contents: |
     Now we'll report the current license counts to the Vendor Portal
 tabs:
-- title: Shell
+- id: lzrwoz9dnvgx
+  title: Shell
   type: terminal
   hostname: shell
   workdir: /home/replicant
-- title: Vendor Portal
+- id: 6evm0inhnqdh
+  title: Vendor Portal
   type: website
   url: https://vendor.replicated.com
   new_window: true

--- a/instruqt/protecting-your-assets/track.yml
+++ b/instruqt/protecting-your-assets/track.yml
@@ -29,6 +29,11 @@ lab_config:
   overlay: false
   width: 25
   position: right
+  sidebar_enabled: true
   feedback_recap_enabled: true
+  feedback_tab_enabled: false
   loadingMessages: true
-checksum: "17501729648192825378"
+  hideStopButton: false
+  default_layout: AssignmentRight
+  default_layout_sidebar_size: 25
+checksum: "5363396849815572745"

--- a/instruqt/protecting-your-assets/track.yml
+++ b/instruqt/protecting-your-assets/track.yml
@@ -36,4 +36,4 @@ lab_config:
   hideStopButton: false
   default_layout: AssignmentRight
   default_layout_sidebar_size: 25
-checksum: "5363396849815572745"
+checksum: "9389913876844819238"

--- a/instruqt/protecting-your-assets/track_scripts/setup-shell
+++ b/instruqt/protecting-your-assets/track_scripts/setup-shell
@@ -41,7 +41,7 @@ get_slackernews
 yq -i '.version = "0.2.0"' slackernews/Chart.yaml
 replicated_sdk_version=$(get_replicated_sdk_version)
 yq -i ".dependencies = []" slackernews/Chart.yaml
-yq -i ".dependencies += { \"name\": \"replicated\", \"repository\": \"oci://registry.replicated.com/library\", \"version\": \"${replicated_sdk_version#?}\"}" slackernews/Chart.yaml
+yq -i ".dependencies += { \"name\": \"replicated\", \"repository\": \"oci://registry.replicated.com/library\", \"version\": \"${replicated_sdk_version}\"}" slackernews/Chart.yaml
 
 # update dependencies
 helm dependency update slackernews


### PR DESCRIPTION
TL;DR
-----

Stops track setup scripts from stripping the `1` from the SDK version

Details
-------

Fixes a defect in track setup scripts for the "Avoiding Installation
Pitfalls", "Closing the Support Installation Gap", and "Protecting Your
Assets" labs that caused the `1` to be stripped from the SDK version
when the track was created. This defect was introduced when I updated the
function that fetches the SDK version to use the chart registry instead of
GitHub. 

The old code resulted in a version string that included a `v` at the
beginning from the GitHub tag, which was stripped on use. The version tags in
the registry do not have a `v` prefix, and I had lazily removed the `v` prefix
by dropping the first character of the version string. This resulted in the
`1` being stripped once the function changes. This change removes the
expressions that dropped the first character of the version string.

It also assures that track metadata updates Instruqt inserted into several
files in the affected labs is under source control.
