### PR TITLE
Repairs solve for first "Delivering..." challenge

### DIFF
--- a/instruqt/delivering-as-an-appliance/01-specifying-the-cluster/solve-shell
+++ b/instruqt/delivering-as-an-appliance/01-specifying-the-cluster/solve-shell
@@ -39,6 +39,17 @@ MANIFEST
 # make sure all files in the release directory are owned by the replicant user
 chown -R replicant:replicant ${HOME_DIR}/release
 
+### Assure the tmux session exists
+#
+# In a test scenario Instuqt does not run the user shell for the
+# challenge, which means the tmux session is never established. We
+# need to session for the solve scripts for other challenges to 
+# succeed, so let's create it here.
+#
+if ! tmux has-session -t shell ; then
+  tmux new-session -d -s shell su - replicant
+fi
+
 # make sure the user has the CLI environment variables set up in their sehll
 tmux send-keys -t shell export SPACE 'REPLICATED_API_TOKEN=' "$(agent variable get REPLICATED_API_TOKEN)" ENTER
 tmux send-keys -t shell export SPACE 'REPLICATED_APP=' "$(agent variable get REPLICATED_APP)" ENTER


### PR DESCRIPTION
TL;DR
-----

Makes sure the tmux sesesion exists to avoid solve script error

Details
-------

Fixes an issues where tests were failing because the solve script for
the first challenge in the "Delivering Your Application as a Kubernetes
Appliacne" lab was trying to send to tmux before the session existed.
